### PR TITLE
Fix deploy script

### DIFF
--- a/utils/scripts/deploy
+++ b/utils/scripts/deploy
@@ -2,7 +2,7 @@
 # Commits all changed files and pushes to GitHub target branch.
 set -e # Exit with nonzero exit code if anything fails
 
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/../.."
 
 # Save some useful information
 REPO=`git config remote.origin.url`


### PR DESCRIPTION
* The `scripts` directory was moved under `utils`, so adjust the initial change directory call, so that we still go to the root of the project.