### PR TITLE
fix renderWindow bug for mobile device

### DIFF
--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -91,6 +91,10 @@ html, body
   }
 }
 
+.md-app-content{
+  padding: 0px;
+}
+
 .md-menu-content{
   z-index: 9999;
 }


### PR DESCRIPTION
* Window plugin was not rendered properly on mobile device due to `renderWindow()` is executed before the container is created.
* Remove the 4pixel padding for small screen device.