### PR TITLE
Improve file loading

### DIFF
--- a/web/src/components/Whiteboard.vue
+++ b/web/src/components/Whiteboard.vue
@@ -3,10 +3,10 @@
   <div @mousemove="overlayMousemove" class="overlay" @click="show_overlay=false" v-if="show_overlay"></div>
   <grid-layout v-if="mode=='grid'" :layout="windows" :col-num="col_num" :is-mirrored="false" :auto-size="true" :row-height="row_height" :col-width="column_width" :is-responsive="true" :is-draggable="true" :is-resizable="true" :vertical-compact="true" :margin="[3, 3]" :use-css-transforms="true">
     <grid-item v-for="(w, wi) in windows" drag-allow-from=".drag-handle" drag-ignore-from=".no-drag" :x="w.x" :y="w.y" :w="w.w" :h="w.h" :i="w.i" @resize="viewChanging(w)" @move="viewChanging(w)" @resized="show_overlay=false;w.resize&&w.resize();focusWindow(w)" @moved="show_overlay=false;w.move&&w.move();focusWindow(w)" :key="w.id">
-      <window :w="w" :withDragHandle="true" @duplicate="duplicate" @select="selectWindow" @close="close" @fullscreen="fullScreen" @normalsize="normalSize"></window>
+      <window :w="w" :withDragHandle="true" @duplicate="duplicate" @select="selectWindow" :loaders="loaders" @close="close" @fullscreen="fullScreen" @normalsize="normalSize"></window>
     </grid-item>
   </grid-layout>
-  <window v-if="mode=='single'" v-for="w in windows" :key="w.id" v-show="selected_window==w" :withDragHandle="false" @duplicate="duplicate" @select="selectWindow" @close="close" @fullscreen="fullScreen" @normalsize="normalSize" :w="w"></window>
+  <window v-if="mode=='single'" v-for="w in windows" :key="w.id" v-show="selected_window==w" :loaders="loaders" :withDragHandle="false" @duplicate="duplicate" @select="selectWindow" @close="close" @fullscreen="fullScreen" @normalsize="normalSize" :w="w"></window>
   <div class="md-layout md-gutter md-alignment-center-center">
     <md-empty-state v-if="!windows || windows.length==0" md-icon="static/img/anna-palm-icon-circle-animation.svg" md-label="IMJOY.IO" md-description="">
     </md-empty-state>

--- a/web/src/components/Window.vue
+++ b/web/src/components/Window.vue
@@ -149,6 +149,12 @@ export default {
         return false
       }
     },
+    loaders: {
+      type: Object,
+      default: function() {
+        return null
+      }
+    }
   },
   data() {
     return {


### PR DESCRIPTION
File loaders are broken due to recent comments, this PR is aiming for fix that and also improve the file loading. Specifically, open the file directly if there is only one file loader found for the current file. For example, when open an image file (.png/.jpg etc.), it should show up immediately if no other file loader registered for the current file type.