### PR TITLE
Reorganize build output folder

### DIFF
--- a/utils/scripts/deploy
+++ b/utils/scripts/deploy
@@ -29,6 +29,9 @@ git checkout $TARGET_BRANCH || { git checkout --orphan $TARGET_BRANCH; git rm -r
 git config user.name "Travis CI"
 git config user.email "travis@travis-ci.org"
 
+# Remove all existing files
+rm -rf ./*
+
 # Copy dirs and files and that we want to update.
 cp -Rf ../web/dist/* ./
 

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -1,8 +1,11 @@
 {
- "name": "ImJoy.io",
-  "start_url": "/index.html",
-  "display": "standalone",
-  "orientation": "portrait",
+ "name": "ImJoy.IO",
+ "short_name": "ImJoy",
+ "start_url": "/index.html",
+ "display": "standalone",
+ "orientation": "portrait",
+ "theme_color": "#448aff",
+ "background_color": "#fff",
  "icons": [
   {
    "src": "\/static\/icons\/android-icon-36x36.png",

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -6,6 +6,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin')
 module.exports = {
   runtimeCompiler: true,
   outputDir: './dist',
+  assetsDir: 'static',
   devServer: {
     compress: true,
     port: 8000
@@ -17,7 +18,7 @@ module.exports = {
         to: path.join(__dirname, "dist/docs/index.html"),
         toType: "file"
       }]),
-      new MonacoWebpackPlugin(),
+      new MonacoWebpackPlugin({output: 'static/vs'}),
       new webpack.DefinePlugin({
         //bypass process check, https://github.com/Microsoft/monaco-editor-webpack-plugin/issues/28
         //TODO: remove this when the bug is fixed


### PR DESCRIPTION
* Clean up the build folder by grouping static files into `static`
* move the files generated by `MonacoWebpackPlugin` to `static/vs`
* add theme-color and short-name etc. to `manifest.json`