### PR TITLE
Add `api.utils.sleep`

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.8.20",
+  "version": "0.8.21",
   "private": true,
   "description": "Image processing with joy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -416,13 +416,14 @@ content = await api.getAttachment("att_name").then(callback)
 
 ## `api.utils.XXXX(...)`
 For Javascript plugins, currently supported functions are:
-`api.utils.$forceUpdate` for force refreshing the GUI.
-`api.utils.openUrl` for open an url in a new browser tab.
+`api.utils.$forceUpdate`: refreshing the GUI manually.
+`api.utils.openUrl`: opening an url in a new browser tab.
+`api.utils.sleep`: sleep for a number of seconds.
 
 For Python Plugins, currently supported functions are:
-`api.utils.kill` for kill a `subprocess` in python.
+`api.utils.kill`: kill a `subprocess` in python.
 
-`api.utils.ndarray` for wrapping ndarray according to ImJoy ndarray format.
+`api.utils.ndarray`: wrap ndarray according to ImJoy ndarray format.
 
 ## `api.TAG` constant
 The current tag choosen by the user during installation.

--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -415,15 +415,15 @@ content = await api.getAttachment("att_name").then(callback)
 ```
 
 ## `api.utils.XXXX(...)`
-For Javascript plugins, currently supported functions are:
-`api.utils.$forceUpdate`: refreshing the GUI manually.
-`api.utils.openUrl`: opening an url in a new browser tab.
-`api.utils.sleep`: sleep for a number of seconds.
+For all the plugins, currently supported functions are:
+ * `api.utils.$forceUpdate`: refreshing the GUI manually.
+ * `api.utils.openUrl`: opening an url in a new browser tab.
+ * `api.utils.sleep`: sleep for a number of seconds. (for Python plugins, use `time.sleep` instead.)
 
 For Python Plugins, currently supported functions are:
-`api.utils.kill`: kill a `subprocess` in python.
+ * `api.utils.kill`: kill a `subprocess` in python.
 
-`api.utils.ndarray`: wrap ndarray according to ImJoy ndarray format.
+ * `api.utils.ndarray`: wrap ndarray according to ImJoy ndarray format.
 
 ## `api.TAG` constant
 The current tag choosen by the user during installation.

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -33,7 +33,7 @@ class ImJoyPlugin {
 
   }
 
-  run(my) {
+  async run(my) {
     console.log('running in the plugin ', my)
 
   }
@@ -73,7 +73,7 @@ class ImJoyPlugin {
 
   }
 
-  run(my) {
+  async run(my) {
     console.log('running in the plugin ', my)
 
   }
@@ -113,7 +113,7 @@ class ImJoyPlugin {
 
   }
 
-  run(my) {
+  async run(my) {
     console.log('running in the plugin ', my)
 
   }
@@ -206,7 +206,6 @@ class ImJoyPlugin():
 
     def run(self, my):
         print('hello world.')
-
 
 api.export(ImJoyPlugin())
 </script>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -804,7 +804,7 @@ export default {
       getAttachment: this.getAttachment,
       getFileUrl: this.getFileUrl,
       getFilePath: this.getFilePath,
-      utils: {$forceUpdate: this.$forceUpdate, openUrl: this.openUrl},
+      utils: {$forceUpdate: this.$forceUpdate, openUrl: this.openUrl, sleep: this.sleep},
     }
 
     this.resetPlugins()
@@ -3018,6 +3018,9 @@ export default {
     },
     openUrl(url){
       Object.assign(document.createElement('a'), { target: '_blank', href: url}).click();
+    },
+    sleep(seconds) {
+      return new Promise(resolve => setTimeout(resolve, Math.round(seconds*1000)));
     }
   }
 }

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2303,7 +2303,7 @@ export default {
       const w = this.active_windows[this.active_windows.length - 1] || {}
       const mw = this.plugin2joy(w) || {}
       mw.target = mw.target || {}
-      mw.target._op = '__op__'
+      mw.target._op = op.name
       mw.target._source_op = null
       // mw.target._transfer = true
       mw.target._workflow_id = mw.target._workflow_id || "op_"+op.name.trim().replace(/ /g, '_')+randId()


### PR DESCRIPTION
Sleep function is used in python as a useful utility function, however, in JS there is no native sleep function. So we provide a `api.utils.sleep` function. The usage is as other ImJoy api functions. It would only make sense to be used in `async` functions and add `await` before the function.

For example:

```javascript
async foo(){
  ...
  //sleep for 3 seconds
  await api.utils.sleep(3)
  ...
}
```