### PR TITLE
add `api.getPlugin` function

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.8.22",
+  "version": "0.8.30",
   "private": true,
   "description": "Image processing with joy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -185,6 +185,37 @@ await api.call("PluginX", "funcX", 1)
 [Try yourself >>](https://imjoy.io/#/app?plugin=oeway/ImJoy-Demo-Plugins:call&w=examples)
 
 
+### api.getPlugin
+```JavaScript
+plugin = await api.getPlugin(plugin_name)
+```
+
+Gets the API object of another plugin.
+
+**Arguments**
+
+* **plugin_name**: String. Name of another plugin.
+
+**Returns**
+* **plugin**: Promise. A promise which can be used to retrieve the API object.
+
+**Example**
+To get the API of a plugin named `PluginX`, with the api object,
+you can then access all the api functions of the plugin:
+
+``` javascript
+pluginX = await api.call("PluginX")
+
+result = await pluginX.run({})
+
+// asuming that PluginX defined an API function called `foo`, you can it with:
+await pluginX.foo()
+```
+
+**Note** about `api.getPlugin` and `api.call`: if you want to constantly access different functions from another plugin,
+it's better to get all the API of that plugin with `api.getPlugin`, then access it through the returned object. If you only access
+the API function in another plugin occasionally, you can use both.
+
 ### api.export
 ```javascript
 api.export(new ImJoyPlugin())

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -801,6 +801,7 @@ export default {
       showStatus: this.showStatus,
       run: this.runPlugin,
       call: this.callPlugin,
+      getPlugin: this.getPluginAPI,
       showPluginProgress: this.showPluginProgress,
       showPluginStatus: this.showPluginStatus,
       showFileDialog: this.showFileDialog,
@@ -2589,6 +2590,16 @@ export default {
         throw 'plugin with type '+plugin_name+ ' not found.'
       }
     },
+    async getPluginAPI(plugin_name) {
+      const target_plugin = this.plugin_names[plugin_name]
+      console.log('======', plugin_name, target_plugin)
+      if(target_plugin){
+        return target_plugin.api
+      }
+      else{
+        throw 'plugin with type '+plugin_name+ ' not found.'
+      }
+    },
     async runPlugin(plugin_name, my, _plugin) {
       let source_plugin
       if(_plugin && _plugin.id){
@@ -3216,7 +3227,7 @@ button.md-speed-dial-target {
 }
 
 .speed-dial-icon {
-  color: gray!important;
+  color: rgba(0,0,0,0.87)!important;
 }
 
 .md-speed-dial-content {


### PR DESCRIPTION
 * add api.getPlugin for getting the plugin api object in another plugin. as an alternative way to interact with other plugins, this api function will return the api object of another plugin by giving the plugin name. For example:
```js
fooPlugin = await api.getPlugin('Foo Plugin')

await fooPlugin.run()
await fooPlugin.bar()
```