### PR TITLE
Improve createWindow api

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.8.30",
+  "version": "0.8.32",
   "private": true,
   "description": "Image processing with joy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -352,7 +352,7 @@ result2 = await api.run("name of plugin 2")
 
 ### api.createWindow
 ```javascript
-window_id = await api.createWindow({name: window_name, type: window_type, w:w, h:h, data: data, config:config},clickload:false)
+win = await api.createWindow({name: window_name, type: window_type, w:w, h:h, data: data, config:config})
 ```
 Creates a new window in the ImJoy workspace.
 
@@ -377,82 +377,51 @@ the window with `api.updateWindow`.
 * **w**: Integer. Window width in inches. **[TODO] Correct?**
 * **h**: Integer. Window height in inches.  **[TODO] Correct?**
 * **data**: Object (JavaScript) or dictionary (Python). Contains data to be tranferred to window.
-* **clickload**: Boolean. If true, window will ask for an extra click to load the content.
 * **config**: Object (JavaScript) or dictionary (Python). **[TODO]**.
 
 **Returns**
 
-* **window_id**: String. Unique window ID.
+* **win**: Object. The API object of the created window.
 
 **Examples**
 ```javascript
-window_id = await api.createWindow({name: 'new window', type: 'Image Window', w:7, h:7, data: {image: ...}, config: {}})
+win = await api.createWindow({name: 'new window', type: 'Image Window', w:7, h:7, data: {image: ...}, config: {}})
 ```
 [Try yourself >>](https://imjoy.io/#/app?plugin=oeway/ImJoy-Demo-Plugins:createWindow&w=examples)
 
 In python you can either use the `async/await` style for Python 3
 
 ```python
-window_id = await api.createWindow(name='new window', type='Image Window', w=7, h=7, data={image: ...}, config={})
+win = await api.createWindow(name='new window', type='Image Window', w=7, h=7, data={image: ...}, config={})
 ```
 
 or the `callback` style for Python 2
 ```python
-def window_callback(window_id):
-    print(window_id)
+def window_callback(win):
+    self.win = win
+    print('window created')
+
 api.createWindow({name: 'new window', type: 'Image Window', w:7, h:7, data: {image: ...}, config: {}}).then(window_callback)
 ```
 
-### api.updateWindow
-```javascript
-window_id = await api.updateWindow({id: window_id, name: window_name, type: window_type, w:w, h:h, data: data, config:config},clickload:false)
-```
+The returned window object from `createWindow` can be stored in the plugin class (`self` for Python, or `this` for JavaScript) for later use.
 
-Updates an existing window.
+For example, you can then use it to update the window.
 
-An minimal call contains the window ID and the data that should be transmitted.
-The data will be passed as `my.data` to the `run` function of the target window
-plugin. If the target window is a internally supported window (e.g. `imjoy/image`),
-then it will just replace the content (since there is no `run` function).
-
-If the previous window was closed, the minimal call will throw an error. However,
-you can also pass `name` and `type` as for `api.createWindow`. If these two fields
-exists, `api.updateWindow` will call `api.createWindow` to create a new window.
-If `api.createWindow` is called, the `windowId` will to be updated, therefore, you
-should save the returned `windowId`.
-
-**Arguments**
-
-Supports same parameters as `api.createWindow`
-
-* **window_id**: String. Window ID returned by `api.createWindow`
-
-
-**Returns**
-
-* **window_id**: String. Unique window ID.
-
-**Examples**
-
-Update a window in JavaScript
-```javascript
-windowId = await api.updateWindow({id: windowId, name: 'new window', type: 'Image Window', w:7, h:7, data: {image: ...}})
-```
-[Try yourself in the createWindow example >>](https://imjoy.io/#/app?plugin=oeway/ImJoy-Demo-Plugins:createWindow&w=examples)
-
-
-Update a window in Python
+For Python:
 ```python
+# win is the object retured from api.createWindow
 # pass as a dictionary
-window_id = await api.updateWindow({'id': window_id, name: 'new window', type: 'Image Window', w:7, h:7, 'data': {'image': ...}})
+await win.run({'data': {'image': ...}})
 
 # or named arguments
-window_id = await api.updateWindow(id=window_id, name='new window', type='Image Window', w=7, h=7, data={'image': ...})
+await win.run(data={'image': ...})
+```
 
-# callback style
-def cb(wid):
-    window_id = wid
-api.updateWindow({'id': window_id, name: 'new window', type: 'Image Window', w:7, h:7, 'data': {'image': ...}}).then(cb)
+For Javascript:
+```javascript
+// win is the object retured from api.createWindow
+await win.run({'data': {'image': ...}})
 ```
 
 ### api.showDialog

--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -424,6 +424,15 @@ For Javascript:
 await win.run({'data': {'image': ...}})
 ```
 
+**Note** about `api.getPlugin` and `api.createWindow`: both of these two api can be used for getting the plugin api for `window` plugins,
+however, they are different. This difference from how ImJoy handles different plugin types. When ImJoy load plugins which is not `window` plugin, a standalone python process, webworker or iframe will be started for each plugin and there will be only one instance of the plugin running. `window` plugins will only be registered and a proxy plugin will be created. No actual instance will be started unless the user clicked the plugin menu or executed by another plugin. And each window in the workspace is a new instance of the `window` plugin.
+
+When `api.getPlugin` is called, it will return the api of the proxy plugin (e.g. `proxy = await api.getPlugin('Image Window')`), every time the `run` function of the proxy plugin api is executed, a new window will be created, for example, if you run `proxy.run({data: ...})` for 10 times, you will get 10 windows.
+
+When `api.createWindow` is used, it will return an instance of the window plugin (e.g. `win = await api.createWindow({'name': 'new window', 'type': 'Image Window', 'data': {...}})`), after that if you run `win.run({'data': ...})` for 10 times, the same window instance will be updated.
+
+Therefore, in most of the cases, you should use `api.createWindow` with `window` plugin, and use `api.getPlugin` for other types of plugins.
+
 ### api.showDialog
 ```javascript
 answer = await api.showDialog(dialog)

--- a/web/public/docs/development.md
+++ b/web/public/docs/development.md
@@ -46,10 +46,7 @@ Since it's designed for perfoming computational tasks, it does not have access t
 Window plugins are used to create a new web interface with HTML/CSS and Javascript.
 They in the `iframe` mode, and it will show up as a window. The `<window>` and `<style>` blocks (see below) can be used to define the actual content of the window.
 
-Different from other plugins which will be loaded and intialized when ImJoy is started, a `window` plugin will not be loaded until the actuall plugin is created with `api.createWindow` or clicked by a user in the menu. During execution of `api.createWindow`, `setup` and `run` will be called for the first time, and return with an window ID. After that, if needed, another plugin can call `api.updateWindow` with the window ID, ImJoy will try to execute the `run` function with the new data again.
-
-If the `run` returned with an object, then it will be used to update the window status managed by ImJoy. This means, for example, if the user changed the name of the plugin, it can be achieved by returning the same `my` object in the `run` function.
-
+Different from other plugins which will be loaded and intialized when ImJoy is started, a `window` plugin will not be loaded until the actuall plugin is created with `api.createWindow` or clicked by a user in the menu. During execution of `api.createWindow`, `setup` and `run` will be called for the first time, and return with an window api object (contains all the api functions of the window, including `setup`, `run` and other functions if defined). You can then use the window api object to access all the functions, for example, update the content of the window by `win_obj.run({'data': ... })`.
 
 ### Native Python
 Used to run Python code. This requires that the **Python Plugin Engine** is installed and started before using the plugin. See the **Developing Python Plugins** for more details.

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -972,6 +972,8 @@ function randId() {
         this._site.onRemoteUpdate(function(){
             me.remote = me._site.getRemote();
             me.api = me.remote;
+            me.api.__jailed_type__ = 'plugin_api';
+            me.api.__id__ = me.id;
             me._disconnected = false
             me.initializing = false
             me._connect.emit();

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -239,7 +239,6 @@ export const WINDOW_SCHEMA= ajv.compile({
     config: {type: 'object'},
     data: {type: ['null', 'object']}, //attachments: {}
     panel: {type: ['null', 'object']}
-    // click2load: Boolean
   }
 })
 

--- a/web/src/buildManifest.js
+++ b/web/src/buildManifest.js
@@ -62,6 +62,10 @@ function get_plugins(files){
 function get_collections(collections_dir){
   return new Promise((resolve, reject)=>{
     var collection_configs = [];
+    if (!fs.existsSync(collections_dir)) {
+      reject('collection folder not exists')
+      return
+    }
     // Loop through all the files in the temp directory
     fs.readdir(collections_dir, function(err, files) {
       if (err) {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -3022,6 +3022,7 @@ export default {
         });
       })
     },
+    //TODO: remove updateWindow from api
     async updateWindow(wconfig, _plugin){
       api.showMessage('Warning: `api.updateWindow` is deprecated, please use the new api.`')
       const w = wconfig.id

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -808,7 +808,7 @@ export default {
       showStatus: this.showStatus,
       run: this.runPlugin,
       call: this.callPlugin,
-      getPlugin: this.getPluginAPI,
+      getPlugin: this.getPlugin,
       showPluginProgress: this.showPluginProgress,
       showPluginStatus: this.showPluginStatus,
       showFileDialog: this.showFileDialog,
@@ -2541,7 +2541,6 @@ export default {
         }
         this.plugins[plugin.id] = plugin
         this.plugin_names[plugin.name] = plugin
-        config.click2load = false
         plugin.api = {
           run: async (my) => {
             const c = _clone(template.defaults) || {}
@@ -2644,7 +2643,7 @@ export default {
         throw 'plugin with type '+plugin_name+ ' not found.'
       }
     },
-    async getPluginAPI(plugin_name) {
+    async getPlugin(plugin_name) {
       const target_plugin = this.plugin_names[plugin_name]
       if(target_plugin){
         return target_plugin.api
@@ -2998,7 +2997,7 @@ export default {
                   pconfig[k] = result[k]
                 }
               }
-              resolve()
+              resolve(plugin.api)
               this.$forceUpdate()
             }).catch((e) => {
               this.status_text = '<' + plugin.name + '>' + (e.toString() || "Error.")
@@ -3024,27 +3023,10 @@ export default {
       })
     },
     async updateWindow(wconfig, _plugin){
-      const wid = wconfig.id
-      if(!wid) throw "You must provide a window id for updating."
-      const w = this.window_ids[wid]
-      if(w){
-        if(w.update){
-          const ret = await w.update(wconfig)
-          if(ret){
-            for(let k in ret){
-              w[k] = ret[k]
-            }
-          }
-        }
-        else{
-          for(let k in wconfig){
-            w[k] = wconfig[k]
-          }
-        }
-        return wid
-      }
-      else if(wconfig.name && wconfig.type){
-        return await this.createWindow(wconfig, _plugin)
+      api.showMessage('Warning: `api.updateWindow` is deprecated, please use the new api.`')
+      const w = wconfig.id
+      if(w && w.run){
+        return await w.run(wconfig)
       }
       else{
         throw `Window (id=${wid}) not found`
@@ -3054,7 +3036,6 @@ export default {
       return new Promise((resolve, reject) => {
         wconfig.config = wconfig.config || {}
         wconfig.data = wconfig.data || null
-        wconfig.click2load = wconfig.click2load || false
         wconfig.panel = wconfig.panel || null
         if (!WINDOW_SCHEMA(wconfig)) {
           const error = WINDOW_SCHEMA.errors(wconfig)
@@ -3065,7 +3046,18 @@ export default {
         if (wconfig.type && wconfig.type.startsWith('imjoy')) {
           // console.log('creating imjoy window', wconfig)
           wconfig.id = 'imjoy_'+randId()
-          resolve(this.addWindow(wconfig))
+          const wid = this.addWindow(wconfig)
+          const window_plugin_apis = {
+            __jailed_type__: 'plugin_api',
+            __id__: wid,
+            run: (wconfig)=>{
+              const w = this.window_ids[wid]
+              for(let k in wconfig){
+                w[k] = wconfig[k]
+              }
+            }
+          }
+          resolve(window_plugin_apis)
         } else {
           const window_config = this.registered.windows[wconfig.type]
           // console.log(window_config)
@@ -3088,19 +3080,15 @@ export default {
           pconfig.iframe_window = null
           pconfig.plugin = window_config
           pconfig.context = this.pluing_context
-          if (!pconfig.click2load) {
-            this.showPluginWindow(pconfig)
-            // make sure the iframe container is ready
-            this.$nextTick(() => {
-              this.renderWindow(pconfig).then(()=>{
-                resolve(pconfig.id)
-              })
-        		});
-          } else {
-            pconfig.renderWindow = this.renderWindow
-            this.showPluginWindow(pconfig)
-            resolve(pconfig.id)
-          }
+
+          this.showPluginWindow(pconfig)
+          // make sure the iframe container is ready
+          this.$nextTick(() => {
+            this.renderWindow(pconfig).then((plugin_api)=>{
+              resolve(plugin_api)
+            })
+      		});
+
         }
       })
     },

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -796,9 +796,7 @@ export default {
       this.engine_url = localStorage.getItem("imjoy_engine_url") || 'http://127.0.0.1:8080'
     }
 
-
-
-    this.plugin_api = {
+    this.imjoy_api = {
       alert: this.showAlert,
       register: this.register,
       createWindow: this.createWindow,
@@ -2542,6 +2540,8 @@ export default {
         this.plugins[plugin.id] = plugin
         this.plugin_names[plugin.name] = plugin
         plugin.api = {
+          __jailed_type__: 'plugin_api',
+          __id__: plugin.id,
           run: async (my) => {
             const c = _clone(template.defaults) || {}
             c.type = template.name
@@ -2584,7 +2584,7 @@ export default {
         }
         const tconfig = _.assign({}, template, config)
         tconfig.workspace = this.selected_workspace
-        const plugin = new jailed.DynamicPlugin(tconfig, _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace}, this.plugin_api))
+        const plugin = new jailed.DynamicPlugin(tconfig, _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace}, this.imjoy_api))
         plugin.whenConnected(() => {
           if (!plugin.api) {
             console.error('Error occured when loading plugin.')
@@ -2974,7 +2974,7 @@ export default {
         // console.log('rendering window', pconfig)
         const tconfig = _.assign({}, pconfig.plugin, pconfig)
         tconfig.workspace = this.selected_workspace
-        const plugin = new jailed.DynamicPlugin(tconfig, _.assign({TAG: pconfig.tag, WORKSPACE: this.selected_workspace}, this.plugin_api))
+        const plugin = new jailed.DynamicPlugin(tconfig, _.assign({TAG: pconfig.tag, WORKSPACE: this.selected_workspace}, this.imjoy_api))
         plugin.whenConnected(() => {
           if (!plugin.api) {
             console.error('the window plugin seems not ready.')

--- a/web/src/components/Whiteboard.vue
+++ b/web/src/components/Whiteboard.vue
@@ -166,8 +166,6 @@ export default {
       if (nw.iframe_container)
         nw.iframe_container = 'plugin_window_' + nw.id + randId()
       nw.i = nw.i + "_"
-      if (!nw.click2load)
-        nw.click2load = true
       if (w.renderWindow) {
         nw.renderWindow = w.renderWindow
       }

--- a/web/src/components/Window.vue
+++ b/web/src/components/Window.vue
@@ -120,7 +120,6 @@
   </div>
   <plugin-editor v-else-if="w.type=='imjoy/plugin-editor'" class="no-drag fill-container" :pluginId="w.data.id" :window="w" v-model="w.data.code" :editorId="'editor_'+w.data.id"></plugin-editor>
   <div v-else class="plugin-iframe">
-    <md-button class="iframe-load-button" @click="w.click2load=false;w.renderWindow(w)" v-if="w.click2load">Click to load the window</md-button>
     <div :id="w.iframe_container" class="plugin-iframe">
     </div>
   </div>


### PR DESCRIPTION
* allowing transferring plugin api between plugins, to send the entire api between plugins, you need to add `__jailed_type__="plugin_api"` and `__id__=plugin.id`.
* Improve the api for `createWindow`, it now return the entire window plugin api instead of a window id.
* deprecate `updateWindow` function since the `run` function can now been accessed from the returned api object.

Before this PR:
```js
//create window, it returns an id
window_id = await api.createWindow({name: 'new window', type: 'imjoy/image', data: {...}})

//update window
await api.updateWindow({id: window_id, data: {...}})
```

After this PR:
```js
//create window, it returns an object
win = await api.createWindow({name: 'new window', type: 'imjoy/image', data: {...}})
//update window
await win.run({ data: {...}})

//other functions can also be accessed if it was defined in the window plugin
await win.foo({ data: {...}})
```
