### PR TITLE
Displaying the returned object from plugins; throw error if plugin is terminated/closed

### DIFF
--- a/web/public/docs/api.md
+++ b/web/public/docs/api.md
@@ -212,7 +212,9 @@ result = await pluginX.run()
 await pluginX.funcX()
 ```
 
-**Note** about `api.getPlugin` and `api.call`: if you want to constantly access different functions from another plugin,
+**Note 1** If the plugin is terminated and you try to call its function, you will get an error. One solution to this is to use `try ... catch `(JavaScript) or `try: ... except: ...`(Python) statement to capture the error. (TODO: this does not work for `native-python` plugin yet.)
+
+**Note 2** about `api.getPlugin` and `api.call`: if you want to constantly access different functions from another plugin,
 it's better to get all the API of that plugin with `api.getPlugin`, then access it through the returned object. If you only access
 the API function in another plugin occasionally, you can use both.
 
@@ -406,7 +408,7 @@ api.createWindow({name: 'new window', type: 'Image Window', w:7, h:7, data: {ima
 
 The returned window object from `createWindow` can be stored in the plugin class (`self` for Python, or `this` for JavaScript) for later use.
 
-For example, you can then use it to update the window.
+For example, you can then use it to update the window, or use `onclose` to set a callback function which will be called hen the window is being closed.
 
 For Python:
 ```python
@@ -416,15 +418,26 @@ await win.run({'data': {'image': ...}})
 
 # or named arguments
 await win.run(data={'image': ...})
+
+# set `onclose` callback
+def close_callback():
+    print('closing window.')
+
+win.onclose(close_callback)
 ```
 
 For Javascript:
 ```javascript
 // win is the object retured from api.createWindow
 await win.run({'data': {'image': ...}})
-```
 
-**Note** about `api.getPlugin` and `api.createWindow`: both of these two api can be used for getting the plugin api for `window` plugins,
+// set `onclose` callback
+win.onclose(()=>{
+  console.log('closing window.')
+})
+```
+**Note 1** If the window is closed and you try to call its function, you will get an error, one solution to this is to use `try ... catch `(JavaScript) or `try: ... except: ...`(Python) statement to capture the error.
+**Note 2** about `api.getPlugin` and `api.createWindow`: both of these two api can be used for getting the plugin api for `window` plugins,
 however, they are different. This difference from how ImJoy handles different plugin types. When ImJoy load plugins which is not `window` plugin, a standalone python process, webworker or iframe will be started for each plugin and there will be only one instance of the plugin running. `window` plugins will only be registered and a proxy plugin will be created. No actual instance will be started unless the user clicked the plugin menu or executed by another plugin. And each window in the workspace is a new instance of the `window` plugin.
 
 When `api.getPlugin` is called, it will return the api of the proxy plugin (e.g. `proxy = await api.getPlugin('Image Window')`), every time the `run` function of the proxy plugin api is executed, a new window will be created, for example, if you run `proxy.run({data: ...})` for 10 times, you will get 10 windows.
@@ -560,9 +573,9 @@ config_value = await api.getConfig(config_name)
 ```
 Retrieves configurations for plugin.
 
-**Note1** numbers are converted to strings when saved with `api.setConfig`. They have to be converted back to numbers before using them (in JavaScript use `parseInt()` or `parseFloat()`, in Python `int()` or `float()`).
+**Note 1** numbers are converted to strings when saved with `api.setConfig`. They have to be converted back to numbers before using them (in JavaScript use `parseInt()` or `parseFloat()`, in Python `int()` or `float()`).
 
-**Note2** you can also access the fields defined in the `<config>` block by adding `_` to the field name, for example, if you want to read the plugin name `defined` in the `<config>` block, you can use `plugin_name = await api.getConfig('_name')`.
+**Note 2** you can also access the fields defined in the `<config>` block by adding `_` to the field name, for example, if you want to read the plugin name `defined` in the `<config>` block, you can use `plugin_name = await api.getConfig('_name')`.
 
 **Arguments**
 * **param_name**: String. Name of parameter.

--- a/web/public/docs/development.md
+++ b/web/public/docs/development.md
@@ -295,7 +295,7 @@ Plugins can be written in Javascript or Python, a minimal plugin needs to implem
 
   * **`setup()` function**: executed when a plugin is loaded and initializes
       it.
-  * **`run()` function**: will be called each time a plugin is executed. When executed, an object (for Javascript) or a dictionary (for Python) called `my` will be passed into the function. More in the section **Plugin during runtime ** below.
+  * **`run()` function**: will be called each time a plugin is executed. When executed, an object (for Javascript) or a dictionary (for Python) called `my` will be passed into the function. The returned result will be displayed as a new window or passed to the next `op` in a workflow. More in the section **Plugin during runtime ** below.
   * optional: **`update()` function**: will be called when any setting of the op is changed.
 
 The `lang` property of the `<script>` block is used to specify the used programming language:
@@ -362,22 +362,18 @@ When executing a plugin, it can can access different fields from `my`:
  * `my._variables`
      When the plugin is executed in a workflow, variables will be set in the workflow will be passed as `my._variables`. It will be set to the actual variable value if the user used ops such as `Set [number]`.
 
-You can directly return your result and they will show as a result window. If you
-want to define the type of your result, or return multiple results, you can construct a new `my` variable(dictionary or object) with two fields `config` and `data`.
+You can directly return your result and they will show as a generic result window.
 
-In the example below, two fields named `data_1` and `result_tensor` will be
-displayed in a result window or passed to the next op in a workflow.
+If you want to define the window type of your result, you can return an object with at least two fields `type` and `data`.
+ImJoy will use `type` to find the window for rendering the result stored in `data`.
+
+In the example below, the image from an url will be displayed in a image window or passed to the next op in a workflow.
 
 ```javascript
-   my = {
-      "config": {},
-      "data": {
-         "data_1": {"type": "image/grayscale", "image": img},
-         "result_tensor": {"type": "tensor", "tensor": t}
-      }
-   }
-   return my
+   return { "type": "imjoy/image", "data": {"src": "https://imjoy.io/static/img/imjoy-icon.png"} }
 ```
+
+
 ImJoy use postMessage to exchange data between plugins. This means that for Javascript
 plugins, objects are cloned during the transfer. If large objects are exchanged,
 if the created objects are not directly transferred. To enable that, you can

--- a/web/public/static/jailed/_JailedSite.js
+++ b/web/public/static/jailed/_JailedSite.js
@@ -62,12 +62,10 @@
             function(data){ me._processMessage(data); }
         );
         this._onclose = (cb)=>{
-          console.log('===============pushing callbacks', cb, id)
           this._onclose_callbacks.push(cb)
         }
         this._connection.onDisconnect(
             function(m){
-              console.log('=====disconnecting site==========closing...')
                 me._disconnectHandler(m);
             }
         );
@@ -136,7 +134,6 @@
      * @param {Object} _interface to set
      */
     JailedSite.prototype.setInterface = function(_interface) {
-      console.log('============set interface', this.id)
         _interface.onclose = this._onclose;
         this._interface = _interface;
         this._sendInterface();
@@ -205,11 +202,12 @@
                if(!interface){
                  if(data.promise){
                    var [resolve, reject] = this._unwrap(data.promise, false);
-                   reject('plugin interface not found or closed: ' + data.pid)
+                   reject(`plugin api function is not avaialbe in "${data.pid}", the plugin maybe terminated.`)
                  }
                  else{
-                  console.error('plugin interface not found or closed: ' + data.pid)
+                  console.error(`plugin api function is not avaialbe in ${data.pid}, the plugin maybe terminated.`)
                  }
+                 return
                }
              }
              if(data.name.indexOf('.') !=-1){
@@ -281,6 +279,13 @@
              this._interfaceSetAsRemoteHandler();
              break;
          case 'disconnect':
+             for(let cb of this._onclose_callbacks){
+               try {
+                 cb()
+               } catch (e) {
+                 console.error('error in onclose callback.', e)
+               }
+             }
              this._disconnectHandler();
              this._connection.disconnect();
              break;
@@ -434,13 +439,11 @@
             }
           }
           this._plugin_interfaces[aObject['__id__']] = encoded_interface
-          console.log('===========encoding api', aObject, this.id)
-          //if(aObject.onclose){
+          if(aObject.onclose){
             aObject.onclose(()=>{
-              console.log('===============closing...', this.id)
               delete this._plugin_interfaces[aObject['__id__']]
             })
-          //}
+          }
           return bObject
         }
 
@@ -720,15 +723,7 @@
      */
     JailedSite.prototype.disconnect = function() {
         this._connection.send({type: 'disconnect'});
-        this._connection.disconnect();
-        console.log('=========disconnecting, running callbacks', me._onclose_callbacks, me.id)
-        for(let cb of me._onclose_callbacks){
-          try {
-            cb()
-          } catch (e) {
-            console.error('error in callback.', e)
-          }
-        }
+        setTimeout(this._connection.disconnect, 1000)
     }
 
 

--- a/web/public/static/jailed/_JailedSite.js
+++ b/web/public/static/jailed/_JailedSite.js
@@ -723,7 +723,7 @@
      */
     JailedSite.prototype.disconnect = function() {
         this._connection.send({type: 'disconnect'});
-        setTimeout(this._connection.disconnect, 1000)
+        setTimeout(this._connection.disconnect, 2000)
     }
 
 

--- a/web/public/static/jailed/_JailedSite.js
+++ b/web/public/static/jailed/_JailedSite.js
@@ -281,7 +281,7 @@
          case 'disconnect':
              for(let cb of this._onclose_callbacks){
                try {
-                 cb()
+                 if(cb) cb()
                } catch (e) {
                  console.error('error in onclose callback.', e)
                }

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -1045,7 +1045,7 @@ function randId() {
     DynamicPlugin.prototype.terminate =
            Plugin.prototype.terminate = function(callback) {
         try {
-          if(this.api.onclose && typeof this.api.onclose == 'function'){
+          if(callback && this.api.onclose && typeof this.api.onclose == 'function'){
             this.api.onclose(callback)
           }
           if(this.api.exit && typeof this.api.exit == 'function'){

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -1045,7 +1045,7 @@ function randId() {
     DynamicPlugin.prototype.terminate =
            Plugin.prototype.terminate = function(callback) {
         try {
-          if(callback && this.api && this.api.onclose && typeof this.api.onclose == 'function'){
+          if(callback && typeof callback == 'function' && this.api && this.api.onclose && typeof this.api.onclose == 'function'){
             this.api.onclose(callback)
           }
           if(this.api.exit && typeof this.api.exit == 'function'){
@@ -1068,7 +1068,9 @@ function randId() {
           this.running = false
           // this._initialInterface.$forceUpdate&&this._initialInterface.$forceUpdate();
           this._site&&this._site.disconnect();
-          callback()
+          if(callback && typeof callback == 'function'){
+            callback()
+          }
         }
     }
 

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -1045,7 +1045,7 @@ function randId() {
     DynamicPlugin.prototype.terminate =
            Plugin.prototype.terminate = function(callback) {
         try {
-          if(callback && this.api.onclose && typeof this.api.onclose == 'function'){
+          if(callback && this.api && this.api.onclose && typeof this.api.onclose == 'function'){
             this.api.onclose(callback)
           }
           if(this.api.exit && typeof this.api.exit == 'function'){

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -1045,7 +1045,9 @@ function randId() {
     DynamicPlugin.prototype.terminate =
            Plugin.prototype.terminate = function(callback) {
         try {
-          this.api.onclose(callback)
+          if(this.api.onclose && typeof this.api.onclose == 'function'){
+            this.api.onclose(callback)
+          }
           if(this.api.exit && typeof this.api.exit == 'function'){
             this.api.exit().finally(()=>{
               this._disconnected = true

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -739,7 +739,9 @@ function randId() {
      * Disconnects the plugin when it is not needed anymore
      */
     Connection.prototype.disconnect = function() {
-        this._platformConnection.disconnect();
+        if(this._platformConnection){
+          this._platformConnection.disconnect();
+        }
     }
 
 
@@ -1041,21 +1043,30 @@ function randId() {
     }
 
     DynamicPlugin.prototype.terminate =
-           Plugin.prototype.terminate = function() {
+           Plugin.prototype.terminate = function(callback) {
         try {
-          console.log('disconnecting .........terminating')
-          this.api.exit().finally(()=>{
+          this.api.onclose(callback)
+          if(this.api.exit && typeof this.api.exit == 'function'){
+            this.api.exit().finally(()=>{
+              this._disconnected = true
+              this.running = false
+              // this._initialInterface.$forceUpdate&&this._initialInterface.$forceUpdate();
+              this._site&&this._site.disconnect();
+            })
+          }
+          else{
             this._disconnected = true
             this.running = false
             // this._initialInterface.$forceUpdate&&this._initialInterface.$forceUpdate();
             this._site&&this._site.disconnect();
-          })
+          }
         } catch (e) {
-          // console.error('error occured when terminating the plugin',e)
+          console.error('error occured when terminating the plugin',e)
           this._disconnected = true
           this.running = false
           // this._initialInterface.$forceUpdate&&this._initialInterface.$forceUpdate();
           this._site&&this._site.disconnect();
+          callback()
         }
     }
 

--- a/web/public/static/jailed/jailed.js
+++ b/web/public/static/jailed/jailed.js
@@ -1043,6 +1043,7 @@ function randId() {
     DynamicPlugin.prototype.terminate =
            Plugin.prototype.terminate = function() {
         try {
+          console.log('disconnecting .........terminating')
           this.api.exit().finally(()=>{
             this._disconnected = true
             this.running = false

--- a/web/src/buildManifest.js
+++ b/web/src/buildManifest.js
@@ -53,7 +53,6 @@ function get_plugins(files){
         var config = parsePlugin(code);
         config.uri = file;
         plugin_configs.push(config);
-        console.log('Adding plugin ====>', config.name);
     }
   });
   return plugin_configs

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2983,7 +2983,7 @@ export default {
                   const res = this.plugin2joy(result)
                   if (res) {
                     const w = {}
-                    w.name = res.type || 'result'
+                    w.name = res.name || 'result'
                     w.type = res.type || 'imjoy/generic'
                     w.config = res.data
                     w.data = res.target

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2368,14 +2368,14 @@ export default {
       mw.target._workflow_id = mw.target._workflow_id || "workflow_"+randId()
       joy.workflow.execute(mw.target).then((my) => {
         const w = this.joy2plugin(my)
-        if (w) {
+
+        if(w && w.data && Object.keys(w.data).length>2){
           // console.log('result', w)
-          w.name = 'result'
-          w.type = 'imjoy/generic'
-          if(w.data.length > 3){
-            this.createWindow(w)
-          }
+          w.name = w.name || 'result'
+          w.type = w.type || 'imjoy/generic'
+          this.createWindow(w)
         }
+
         this.progress = 100
       }).catch((e) => {
         console.error(e)
@@ -2443,11 +2443,12 @@ export default {
       // mw.target._transfer = true
       mw.target._workflow_id = mw.target._workflow_id || "op_"+op.name.trim().replace(/ /g, '_')+randId()
       op.joy.__op__.execute(mw.target).then((my) => {
+        console.log('================', my.data)
         const w = this.joy2plugin(my)
         if (w) {
           console.log('result', w)
-          w.name = 'result'
-          w.type = 'imjoy/generic'
+          w.name = w.name || 'result'
+          w.type = w.type || 'imjoy/generic'
           this.createWindow(w)
         }
         this.progress = 100
@@ -2744,14 +2745,18 @@ export default {
       if(!my) return null
       //conver config--> data  data-->target
       const res = {}
-      if(my.data && my.config){
+
+      if(my.type && my.data){
         res.data = my.config
         res.target = my.data
+        res.target.name = my.name
+        res.target.type = my.type
       }
       else{
         res.data = null
         res.target = my
       }
+
       res.target = res.target || {}
       if(Array.isArray(res.target) && res.target.length>0){
         if(my.select !== undefined && res.target[my.select]){
@@ -2798,6 +2803,8 @@ export default {
         _workflow_id: my.target && my.target._workflow_id,
         config: my.data,
         data: my.target,
+        name: my.target && my.target.name,
+        type: my.target && my.target.type
       }
       if(my.target){
         delete my.target._op
@@ -2976,8 +2983,8 @@ export default {
                   const res = this.plugin2joy(result)
                   if (res) {
                     const w = {}
-                    w.name = 'result'
-                    w.type = 'imjoy/generic'
+                    w.name = res.type || 'result'
+                    w.type = res.type || 'imjoy/generic'
                     w.config = res.data
                     w.data = res.target
                     await this.createWindow(w)

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1881,7 +1881,7 @@ export default {
       const plugin = this.plugins[pid]
       const pconfig = plugin.config
       const w = {
-        name: pconfig.name,
+        name: pconfig.name || 'plugin',
         type: 'imjoy/plugin-editor',
         config: {},
         plugin: plugin,
@@ -2443,7 +2443,6 @@ export default {
       // mw.target._transfer = true
       mw.target._workflow_id = mw.target._workflow_id || "op_"+op.name.trim().replace(/ /g, '_')+randId()
       op.joy.__op__.execute(mw.target).then((my) => {
-        console.log('================', my.data)
         const w = this.joy2plugin(my)
         if (w) {
           console.log('result', w)
@@ -3117,6 +3116,7 @@ export default {
         if (wconfig.type && wconfig.type.startsWith('imjoy')) {
           // console.log('creating imjoy window', wconfig)
           wconfig.id = 'imjoy_'+randId()
+          wconfig.name = wconfig.name || 'untitled window'
           const wid = this.addWindow(wconfig)
           const window_plugin_apis = {
             __jailed_type__: 'plugin_api',
@@ -3171,6 +3171,7 @@ export default {
       })
     },
     showPluginWindow(config) {
+      config.name = config.name || 'untitiled plugin window'
       config.type = config.type
       config.data = config.data || null
       config.config = config.config || {}

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2261,6 +2261,7 @@ export default {
       if(this.window_mode == 'single'){
         this.selected_window = this.windows[0]
       }
+      if(ws.plugin) ws.plugin.terminate()
     },
     windowAdded(ws) {
       this.window_ids[ws.id] = ws

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2181,8 +2181,9 @@ export default {
 
       for (var i = this.windows.length; i--;) {
         if (this.windows[i].type != 'imjoy/plugin-editor') {
-            delete this.window_ids[this.windows[i].id]
-            this.windows.splice(i, 1);
+            // delete this.window_ids[this.windows[i].id]
+            // this.windows.splice(i, 1);
+            this.closeWindow(this.windows[i])
         }
       }
 
@@ -2239,6 +2240,13 @@ export default {
       this.active_windows = [w]
       w.refresh()
     },
+    closeWindow(w){
+      this.windows.splice(this.windows.indexOf(w), 1)
+      delete this.window_ids[w.id]
+      if(this.window_mode == 'single'){
+        this.selected_window = this.windows[0]
+      }
+    },
     closePluginDialog(ok) {
       this.showPluginDialog = false
       let [resolve, reject] = this._plugin_dialog_promise
@@ -2257,11 +2265,9 @@ export default {
       this.active_windows = ws
     },
     windowClosed(ws) {
-      delete this.window_ids[ws.id]
-      if(this.window_mode == 'single'){
-        this.selected_window = this.windows[0]
-      }
-      if(ws.plugin) ws.plugin.terminate()
+      if(ws.plugin) ws.plugin.terminate(()=>{
+        this.closeWindow(ws)
+      })
     },
     windowAdded(ws) {
       this.window_ids[ws.id] = ws

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2265,9 +2265,12 @@ export default {
       this.active_windows = ws
     },
     windowClosed(ws) {
-      if(ws.plugin) ws.plugin.terminate(()=>{
+      if(ws.plugin && ws.plugin.terminate) ws.plugin.terminate(()=>{
         this.closeWindow(ws)
       })
+      else{
+        this.closeWindow(ws)
+      }
     },
     windowAdded(ws) {
       this.window_ids[ws.id] = ws
@@ -2707,6 +2710,8 @@ export default {
     async callPlugin(plugin_name, function_name) {
       const target_plugin = this.plugin_names[plugin_name]
       if(target_plugin){
+        if(!target_plugin.running)
+          throw 'plugin "'+plugin_name+ '" is not running.'
         return await target_plugin.api[function_name].apply(null, Array.prototype.slice.call(arguments, 2, arguments.length-1))
       }
       else{
@@ -2733,6 +2738,8 @@ export default {
       }
       const target_plugin = this.plugin_names[plugin_name]
       if(target_plugin){
+        if(!target_plugin.running)
+          throw 'plugin "'+plugin_name+ '" is not running.'
         my = my || {}
         my.op = {type: source_plugin.type, name:source_plugin.name}
         my.config = my.config || {}

--- a/web/src/components/Whiteboard.vue
+++ b/web/src/components/Whiteboard.vue
@@ -139,7 +139,6 @@ export default {
         this.$emit('select', this.active_windows, null)
       }
       this.$emit('close', w)
-      this.windows.splice(this.windows.indexOf(w), 1)
     },
     isTypedArray(obj)
     {


### PR DESCRIPTION
* check if the object returned from a plugin's `run` function has two fields `type` and `run`, if yes, then display as a new window based on the window type.
* support `onclose` to detect whether the plugin is terminated or the window plugin is closed. (TODO: native python plugins do not support this yet.)