### PR TITLE
Support in-browser files system with Browserfs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -415,7 +415,7 @@ var blob = new Blob(["Hello, world!"], {type: "text/plain;charset=utf-8"});
 api.exportFile(blob, 'hello.txt')
 ```
 
-### api.fs
+### api.fs.* [experimental]
 ```javascript
 api.fs.XXXXX(...)
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -420,7 +420,11 @@ api.exportFile(blob, 'hello.txt')
 api.fs.XXXXX(...)
 ```
 
-Access the in-browser filesystem with the [Node JS filesystem API](https://nodejs.org/api/fs.html).
+Access the in-browser filesystem with the [Node JS filesystem API](https://nodejs.org/api/fs.html). More details about the underlying implemetation, see [BrowserFS](https://github.com/jvilk/BrowserFS), the default file system in ImJoy support the following nodes:
+
+ * `/tmp`: `InMemory`, data is stored in browser memory, cleared when ImJoy is closed.
+
+ * `/home`: `IndexedDB`, data is stored in the browser IndexedDB database, can be used as persistent storage.
 
 **Examples**
 <!-- tabs:start -->

--- a/docs/api.md
+++ b/docs/api.md
@@ -415,6 +415,50 @@ var blob = new Blob(["Hello, world!"], {type: "text/plain;charset=utf-8"});
 api.exportFile(blob, 'hello.txt')
 ```
 
+### api.fs
+```javascript
+api.fs.XXXXX(...)
+```
+
+Access the in-browser filesystem with the [Node JS filesystem API](https://nodejs.org/api/fs.html).
+
+**Examples**
+<!-- tabs:start -->
+
+```javascript
+api.fs.writeFile('/tmp/temp.txt', 'hello world', function(err, data){
+    if (err) {
+        console.log(err);
+        return
+    }
+    console.log("Successfully Written to File.");
+    api.fs.readFile('/tmp/temp.txt', 'utf8', function (err, data) {
+        if (err) {
+            console.log(err);
+            return
+        }
+        console.log('Reald from file', data)
+    });
+});
+```
+
+```python
+def read(err, data=None):
+    if err:
+        print(err)
+        return
+
+    def cb(err, data=None):
+        if err:
+            print(err)
+            return
+        api.log(data)
+    api.fs.readFile('/tmp/temp.txt', 'utf8', cb)
+
+api.fs.writeFile('/tmp/temp.txt', 'hello world', read)
+
+```
+<!-- tabs:end -->
 
 ### api.getAttachment
 ```javascript

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2764,6 +2764,25 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "browserfs": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/browserfs/-/browserfs-1.4.3.tgz",
+      "integrity": "sha512-tz8HClVrzTJshcyIu8frE15cjqjcBIu15Bezxsvl/i+6f59iNCN3kznlWjz0FEb3DlnDx3gW5szxeT6D1x0s0w==",
+      "requires": {
+        "async": "^2.1.4",
+        "pako": "^1.0.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        }
+      }
     },
     "browserify-aes": {
       "version": "1.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "ajv": "^6.6.1",
     "axios": "^0.18.0",
+    "browserfs": "^1.4.3",
     "file-loader": "^1.1.4",
     "file-saver": "^1.3.3",
     "glfx": "0.0.4",

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -556,6 +556,11 @@ import {
   EngineManager
 } from '../engineManager.js'
 
+import {
+  FileSystemManager
+} from '../fileSystemManager.js'
+
+
 import _ from 'lodash'
 
 import {
@@ -623,7 +628,8 @@ export default {
       snackbar_duration: 3000,
       show_snackbar: false,
       screenWidth: 1024,
-      plugin_loaded: false
+      plugin_loaded: false,
+      new_workspace_name: ''
     }
   },
   watch: {
@@ -666,6 +672,7 @@ export default {
     this.em = new EngineManager({ event_bus: this.event_bus, show_message_callback: this.showMessage, show_engine_callback: this.showEngineConnection.bind(this)})
     this.wm = new WindowManager({ event_bus: this.event_bus, show_message_callback: this.showMessage, add_window_callback: this.addWindow})
     this.pm = new PluginManager({ event_bus: this.event_bus, engine_manager: this.em, window_manager:this.wm, imjoy_api: imjoy_api, show_message_callback: this.showMessage, update_ui_callback: ()=>{this.$forceUpdate()}})
+    this.fm = new FileSystemManager()
 
     this.client_id = null
     this.IMJOY_PLUGIN = {
@@ -678,7 +685,6 @@ export default {
       // {name: "Iframe(Javascript)", code: IFRAME_PLUGIN_TEMPLATE},
       {name: "Web Python 🐍", code: WEB_PYTHON_PLUGIN_TEMPLATE}
     ]
-    this.new_workspace_name = ''
     this.workflow_joy_config = {
       expanded: true,
       name: "Workflow",

--- a/web/src/fileSystemManager.js
+++ b/web/src/fileSystemManager.js
@@ -9,17 +9,21 @@ export class FileSystemManager {
       BrowserFS.configure({
         fs: "MountableFileSystem",
         options: {
-          '/tmp': { fs: "InMemory" },
-          '/home': { fs: "IndexedDB" },
-          '/mnt/h5': { fs: "HTML5FS" }
+          '/tmp': { fs: "InMemory", options: {storeName: 'tmp'} },
+          '/home': { fs: "IndexedDB", options: {storeName: 'home'} },
+          // '/mnt/h5': { fs: "HTML5FS", options: {} }
         }
-      }, function(e) {
+      }, (e) => {
         if (e) {
           reject(e)
+          return
         }
-        const fs = BrowserFS.BFSRequire('fs');
-        resolve(fs)
+        this.fs = BrowserFS.BFSRequire('fs')
+        resolve(this.fs)
       });
     })
+  }
+  destroy(){
+
   }
 }

--- a/web/src/fileSystemManager.js
+++ b/web/src/fileSystemManager.js
@@ -1,0 +1,25 @@
+import * as BrowserFS from 'browserfs'
+
+export class FileSystemManager {
+  constructor(){
+    this.fs = null
+  }
+  init(){
+    return new Promise((resolve, reject)=>{
+      BrowserFS.configure({
+        fs: "MountableFileSystem",
+        options: {
+          '/tmp': { fs: "InMemory" },
+          '/home': { fs: "IndexedDB" },
+          '/mnt/h5': { fs: "HTML5FS" }
+        }
+      }, function(e) {
+        if (e) {
+          reject(e)
+        }
+        const fs = BrowserFS.BFSRequire('fs');
+        resolve(fs)
+      });
+    })
+  }
+}

--- a/web/src/jailed/_JailedSite.js
+++ b/web/src/jailed/_JailedSite.js
@@ -509,6 +509,7 @@
               bObject[k] = {__jailed_type__: 'ndarray', __value__ : v.selection.data, __shape__: v.shape, __dtype__: dtype}
             }
             else if( v instanceof Error){
+              console.error(v)
               bObject[k] = {__jailed_type__: 'error', __value__ : v.toString()}
             }
             else if(v instanceof File){

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -771,7 +771,7 @@ Connection.prototype.disconnect = function() {
  * @param {String} url of a plugin source
  * @param {Object} _interface to provide for the plugin
  */
-var Plugin = function( config, _interface, is_proxy) {
+var Plugin = function( config, _interface, _fs, is_proxy) {
     this.config = config
     this.id = config.id || randId();
     this._id = config._id;
@@ -793,6 +793,7 @@ var Plugin = function( config, _interface, is_proxy) {
     else{
       this._disconnected = true;
       this._bindInterface(_interface);
+      this._initialInterface.fs = _fs;
       this._connect();
     }
 };
@@ -805,7 +806,7 @@ var Plugin = function( config, _interface, is_proxy) {
  * @param {String} code of the plugin
  * @param {Object} _interface to provide to the plugin
  */
-var DynamicPlugin = function(config, _interface, is_proxy) {
+var DynamicPlugin = function(config, _interface, _fs, is_proxy) {
     this.config = config
     if(!this.config.script){
       throw "you must specify the script for the plugin to run."
@@ -829,6 +830,7 @@ var DynamicPlugin = function(config, _interface, is_proxy) {
     else{
       this._disconnected = true;
       this._bindInterface(_interface);
+      this._initialInterface.fs = _fs;
       this._connect();
     }
     this._updateUI()
@@ -849,7 +851,9 @@ DynamicPlugin.prototype._bindInterface =
      else if(typeof _interface[k] === 'object'){
        var utils = {}
        for(var u in _interface[k]){
-         utils[u] = _interface[k][u].bind(null, this)
+         if(typeof _interface[k][u] === 'function'){
+           utils[u] = _interface[k][u].bind(null, this)
+         }
        }
        this._initialInterface[k] = utils
      }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -41,10 +41,12 @@ import Ajv from 'ajv'
 const ajv = new Ajv()
 
 export class PluginManager {
-  constructor({event_bus=null, engine_manager=null, window_manager=null, imjoy_api={}, show_message_callback=null, update_ui_callback=null}){
+  constructor({event_bus=null, engine_manager=null, window_manager=null, file_system_manager=null, imjoy_api={}, show_message_callback=null, update_ui_callback=null}){
     this.event_bus = event_bus
     this.em = engine_manager
     this.wm = window_manager
+    this.fm = file_system_manager
+
     assert(this.event_bus, 'event bus is not available')
     assert(this.em, 'engine manager is not available')
     assert(this.wm, 'window manager is not available')
@@ -126,7 +128,7 @@ export class PluginManager {
     }
   }
 
-  resetPlugins(){
+  init(){
     this.plugins = {}
     this.plugin_names = {}
     this.registered = {
@@ -520,7 +522,7 @@ export class PluginManager {
           }
         }
       }
-      this.resetPlugins()
+      this.init()
       this.reloadDB().then(()=>{
         this.db.allDocs({
           include_docs: true,
@@ -974,7 +976,7 @@ export class PluginManager {
       const _interface = _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace}, this.imjoy_api)
 
       // create a proxy plugin
-      const plugin = new DynamicPlugin(tconfig, _interface, true)
+      const plugin = new DynamicPlugin(tconfig, _interface, this.fm.fs, true)
 
       this.plugins[plugin.id] = plugin
       this.plugin_names[plugin.name] = plugin
@@ -1025,7 +1027,7 @@ export class PluginManager {
       const tconfig = _.assign({}, template, config)
       tconfig.workspace = this.selected_workspace
       const _interface = _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace}, this.imjoy_api)
-      const plugin = new DynamicPlugin(tconfig, _interface)
+      const plugin = new DynamicPlugin(tconfig, _interface, this.fm.fs)
       plugin.whenConnected(() => {
         if (!plugin.api) {
           console.error('Error occured when loading plugin.')
@@ -1114,7 +1116,7 @@ export class PluginManager {
       const tconfig = _.assign({}, pconfig.plugin, pconfig)
       tconfig.workspace = this.selected_workspace
       const _interface = _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace}, this.imjoy_api)
-      const plugin = new DynamicPlugin(tconfig, _interface)
+      const plugin = new DynamicPlugin(tconfig, _interface, this.fm.fs)
       plugin.whenConnected(() => {
         if (!plugin.api) {
           console.error('the window plugin seems not ready.')

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -140,7 +140,6 @@ export class PluginManager {
       outputs: {},
       loaders: {}
     }
-    this.setInputLoaders(this.getDefaultInputLoaders())
   }
 
   loadRepositoryList(){
@@ -484,24 +483,6 @@ export class PluginManager {
     for(let inputs of input_loaders){
       this.wm.registerInputLoader(inputs.loader_key, inputs, inputs.loader)
     }
-  }
-
-  getDefaultInputLoaders(){
-    const image_loader = (file)=>{
-      const reader = new FileReader();
-      reader.onload =  () => {
-        this.createWindow(null, {
-          name: file.name,
-          type: 'imjoy/image',
-          data: {src: reader.result, _file: file}
-        })
-      }
-      reader.readAsDataURL(file);
-    }
-
-    return [
-      {loader_key:'Image',  schema: ajv.compile({properties: {type: {type:"string", "enum": ['image/jpeg', 'image/png', 'image/gif']}, size: {type: 'number'}}, required: ["type", "size"]}), loader: image_loader},
-    ]
   }
 
   reloadPlugins() {

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -26,6 +26,7 @@ describe('ImJoy.vue', async () => {
   const vm = wrapper.vm //vm of ImJoy
   const wm = vm.wm //window_manager
   const pm = vm.pm //plugin_manager
+  const fm = vm.fm //file_manager
 
   before(function(done) {
     this.timeout(10000)
@@ -121,6 +122,25 @@ describe('ImJoy.vue', async () => {
     plugin.terminate()
   }).timeout(20000)
 
+  it('should write and read file', (done) => {
+    fm.init().then((fs)=>{
+      var c = "New File Contents";
+      fs.writeFile('/tmp/test.txt', c, function(err){
+          if (err){
+            console.error(err);
+          }
+          expect(err).to.be.null
+          fs.readFile('/tmp/test.txt', 'utf8', function (err, data) {
+            if (err){
+              console.error(err);
+            }
+            expect(err).to.be.null
+            expect(data).to.equal(c)
+            done()
+          });
+      });
+    })
+  })
 
   describe('Test ImJoy API', async () => {
     let plugin1

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -137,7 +137,7 @@ describe('ImJoy.vue', async () => {
             expect(err).to.be.undefined
             expect(data).to.equal(c)
             done()
-          });
+          });  
       });
     })
   })

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -129,12 +129,12 @@ describe('ImJoy.vue', async () => {
           if (err){
             console.error(err);
           }
-          expect(err).to.be.null
+          expect(err).to.be.undefined
           fs.readFile('/tmp/test.txt', 'utf8', function (err, data) {
             if (err){
               console.error(err);
             }
-            expect(err).to.be.null
+            expect(err).to.be.undefined
             expect(data).to.equal(c)
             done()
           });

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -94,6 +94,61 @@ class ImJoyPlugin {
     return true
   }
 
+  test_fs() {
+    const fs = api.fs
+    return new Promise((resolve, reject)=>{
+        function generate_random_data(size){
+            var chars = 'abcdefghijklmnopqrstuvwxyz'.split('');
+            var len = chars.length;
+            var random_data = [];
+
+            while (size--) {
+                random_data.push(chars[Math.random()*len | 0]);
+            }
+
+            return random_data.join('');
+        }
+
+        const fs = api.fs
+        fs.writeFile('/tmp/test.txt', generate_random_data(100000), function(err){
+        if (err){
+            console.error(err);
+        }
+        fs.open('/tmp/test.txt', 'r', function(err, fd) {
+            fs.fstat(fd, function(err, stats) {
+                if(err){
+                    reject(err)
+                    return
+                }
+                var bufferSize = stats.size,
+                    chunkSize = 512,
+                    buffer = new Uint8Array(new ArrayBuffer(chunkSize)),
+                    bytesRead = 0;
+
+                var stopReadding = false
+                var readCallback = function(err, bytesRead, read_buffer){
+                    if(err){
+                        console.log('err : ' +  err);
+                        stopReadding = true
+                        reject(err)
+                    }
+                    const bytes = read_buffer.slice(0, bytesRead)
+                    console.log('new chunk:', bytes)
+                };
+                while (bytesRead < bufferSize && !stopReadding) {
+                    if ((bytesRead + chunkSize) > bufferSize) {
+                        chunkSize = (bufferSize - bytesRead);
+                    }
+                    fs.read(fd, buffer, 0, chunkSize, bytesRead, readCallback);
+                    bytesRead += chunkSize;
+                }
+                fs.close(fd);
+                resolve(true)
+            });
+        });
+        })
+    })
+  }
 }
 
 api.export(new ImJoyPlugin())


### PR DESCRIPTION
 * add preliminary support for a in-browser file system with [browserfs](https://github.com/jvilk/BrowserFS)
Plugins can now read/write files using [nodejs filesystem api](http://nodejs.org/api/fs.html) through `api.fs.*`, for example:
```
const fs = api.fs
const c = "New File Contents";
fs.writeFile('/tmp/test.txt', c, function(err){
    if (err){
      console.error(err);
    }
    expect(err).to.be.undefined
    fs.readFile('/tmp/test.txt', 'utf8', function (err, data) {
      if (err){
        console.error(err);
      }
      expect(err).to.be.undefined
      expect(data).to.equal(c)
      done()
    });
});
```

The default file system in ImJoy supports the following nodes:

  1. `/tmp`: `InMemory`, data is stored in browser memory, cleared when ImJoy is closed.

  1.  `/home`: `IndexedDB`, data is stored in the browser IndexedDB database, can be used as persistent storage.


* Fix a bug for code editor.


