### PR TITLE
Support `from imjoy import api` for python plugins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,7 +6,8 @@ plugins and makes the ImJoy App more secure.
 
 Interactions between plugins or between a plugin with the main ImJoy app are carried
 out through a set of API functions (`ImJoy API`). All plugins have access
-to a special object called `api`. With this object plugins can, for example,
+to a special object called `api`. In Javascript, `api` is a global object which you can use directly.
+In Python, you can import it by calling `from imjoy import api`. With this object plugins can, for example,
 show a dialog, send results to the main app, or call another plugin with
 parameters and data.
 
@@ -72,6 +73,7 @@ don't forget to `import asyncio`.
 
 #### ** Python **
 ```python
+from imjoy import api
 import asyncio
 
 class ImJoyPlugin():
@@ -124,6 +126,7 @@ class ImJoyPlugin(){
 
 #### ** Python **
 ```python
+from imjoy import api
 class ImJoyPlugin():
     def setup(self):
         pass

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,8 +73,8 @@ don't forget to `import asyncio`.
 
 #### ** Python **
 ```python
-from imjoy import api
 import asyncio
+from imjoy import api
 
 class ImJoyPlugin():
     async def setup(self):

--- a/docs/api.md
+++ b/docs/api.md
@@ -77,6 +77,7 @@ import asyncio
 
 from imjoy import api
 
+
 class ImJoyPlugin():
     async def setup(self):
         pass

--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,7 @@ don't forget to `import asyncio`.
 #### ** Python **
 ```python
 import asyncio
+
 from imjoy import api
 
 class ImJoyPlugin():

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "private": true,
   "description": "ImJoy -- deploying deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/jailed/_pluginWebPython.js
+++ b/web/src/jailed/_pluginWebPython.js
@@ -95,7 +95,15 @@ var importScript = function(url) {
     }
 }
 
-
+var startup_script = `
+from js import api
+import sys
+from types import ModuleType
+m = ModuleType("imjoy")
+sys.modules[m.__name__] = m
+m.__file__ = m.__name__ + ".py"
+m.api = api
+`
 var _export_plugin_api = null;
 var execute_python_code = function(code) {
   try {
@@ -124,7 +132,7 @@ var execute_python_code = function(code) {
           }
         }
       }
-      pyodide.runPython('from js import api')
+      pyodide.runPython(startup_script)
       pyodide.runPython(code.content)
   } catch (e) {
       throw e;

--- a/web/src/plugins/nativePythonTemplate.imjoy.html
+++ b/web/src/plugins/nativePythonTemplate.imjoy.html
@@ -25,6 +25,7 @@
 <script lang="python">
 from imjoy import api
 
+
 class ImJoyPlugin():
     def setup(self):
         api.log('initialized')

--- a/web/src/plugins/nativePythonTemplate.imjoy.html
+++ b/web/src/plugins/nativePythonTemplate.imjoy.html
@@ -23,7 +23,7 @@
 </config>
 
 <script lang="python">
-# import numpy as np
+from imjoy import api
 
 class ImJoyPlugin():
     def setup(self):

--- a/web/src/plugins/webPythonTemplate.imjoy.html
+++ b/web/src/plugins/webPythonTemplate.imjoy.html
@@ -25,6 +25,7 @@
 <script lang="python">
 from imjoy import api
 
+
 class ImJoyPlugin():
     def setup(self):
         api.log('initialized')

--- a/web/src/plugins/webPythonTemplate.imjoy.html
+++ b/web/src/plugins/webPythonTemplate.imjoy.html
@@ -23,7 +23,7 @@
 </config>
 
 <script lang="python">
-# import numpy as np
+from imjoy import api
 
 class ImJoyPlugin():
     def setup(self):

--- a/web/src/plugins/webPythonWindowTemplate.imjoy.html
+++ b/web/src/plugins/webPythonWindowTemplate.imjoy.html
@@ -23,6 +23,7 @@
 </config>
 
 <script lang="python">
+from imjoy import api
 
 class ImJoyPlugin():
     def setup(self):

--- a/web/src/plugins/webPythonWindowTemplate.imjoy.html
+++ b/web/src/plugins/webPythonWindowTemplate.imjoy.html
@@ -25,6 +25,7 @@
 <script lang="python">
 from imjoy import api
 
+
 class ImJoyPlugin():
     def setup(self):
         api.log('initialized')


### PR DESCRIPTION
* add a fake module called `imjoy` in web-python plugins (and also https://github.com/oeway/ImJoy-Engine/commit/3fa495ab2b72f509840f951fbc759edbef0a96c7 )
* add docs for the import syntax