### PR TITLE
WIP: support deploying and publishing plugins

### DIFF
--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -17,10 +17,10 @@
         <div v-for="engine in engineManager.engines" :key="engine.url">
           <md-divider></md-divider>
           <md-menu-item v-if="engine.connected"  @click="showInfo(engine)">
-            <md-button v-if="engine.show_processes && engine.plugin_processes && engine.plugin_processes.length>0" @click.stop="hide(engine)" class="md-icon-button md-primary">
+            <md-button v-if="engine.show_processes && engine.plugin_processes && engine.plugin_processes.length>0" @click.stop="hide_processes(engine)" class="md-icon-button md-primary">
               <md-icon>remove</md-icon>
             </md-button>
-            <md-button v-else @click.stop="expand(engine)" class="md-icon-button md-primary">
+            <md-button v-else @click.stop="expand_processes(engine)" class="md-icon-button md-primary">
               <md-icon>autorenew</md-icon>
             </md-button>
             <span>{{engine.url.replace(local_engine_url, 'My Computer')}}</span>
@@ -34,7 +34,7 @@
             <md-menu-item v-show="engine.plugin_processes" v-for="p in engine.plugin_processes" :key="p.pid">
               &nbsp;&nbsp;
               - {{p.name}} (#{{p.pid}})
-              <md-button @click.stop="kill(engine, p)" class="md-icon-button md-accent">
+              <md-button @click.stop="kill(engine, p)" class="md-icon-button small-icon-button md-accent">
                 <md-icon>clear</md-icon>
               </md-button>
             </md-menu-item>
@@ -43,12 +43,12 @@
                 <div class="loading loading-lg"></div>
               </md-button>
             </md-menu-item>
-            <md-menu-item :disabled="true" v-if="engine.plugin_num>1">
+            <!-- <md-menu-item :disabled="true" v-if="engine.plugin_num>1">
               <span>&nbsp;&nbsp;{{engine.plugin_num}} Running Plugins</span>
-              <md-button @click.stop="kill(engine)" class="md-icon-button md-accent">
+              <md-button @click.stop="kill(engine)" class="md-icon-button small-icon-button md-accent">
                 <md-icon>clear</md-icon>
               </md-button>
-            </md-menu-item>
+            </md-menu-item> -->
           </div>
         </div>
       </md-menu-content>
@@ -71,6 +71,12 @@
             <label for="engine_url">Plugin Engine URL</label>
           </md-autocomplete>
           <md-field>
+            <md-select v-model="engine_role" name="engine_role">
+              <md-option value="admin">Connect as an admininistrator</md-option>
+              <md-option value="user">Connect as a regular user</md-option>
+            </md-select>
+          </md-field>
+          <md-field v-if="engine_role === 'admin'">
             <label for="connection_token">Connection Token</label>
             <md-input type="password" v-model="connection_token" name="connection_token" @keyup.enter="addEngine()"></md-input>
           </md-field>
@@ -88,8 +94,14 @@
       <md-dialog-content v-if="selected_engine">
         <h3>{{selected_engine.url.replace(local_engine_url, 'My computer ('+local_engine_url+')')}}</h3>
         <md-field>
+          <md-select @md-selected="setting_changed=true" v-model="selected_engine.role" name="engine_role">
+            <md-option value="admin">Connect as an admininistrator</md-option>
+            <md-option value="user">Connect as a regular user</md-option>
+          </md-select>
+        </md-field>
+        <md-field v-if="selected_engine.role === 'admin'">
           <label for="connection_token">Connection Token</label>
-          <md-input type="password" v-model="selected_engine.config.token" @keyup.enter="connectEngine(selected_engine)" name="connection_token"></md-input>
+          <md-input type="password" @change="setting_changed=true" v-model="selected_engine.config.token" @keyup.enter="connectEngine(selected_engine)" name="connection_token"></md-input>
         </md-field>
         <div v-if="selected_engine.connected && show_sys_info && selected_engine.engine_info.platform" class="platform-info">
           <p> - api version: {{selected_engine.engine_info.api_version}}</p>
@@ -98,7 +110,10 @@
         <br>
         <md-button class="md-primary md-raised" v-if="!selected_engine.connected" @click="connectEngine(selected_engine)"><md-icon>sync</md-icon> Connect</md-button>
         <md-button class="md-accent" v-else @click="disconnectEngine(selected_engine)"><md-icon>sync_disabled</md-icon>Disconnect</md-button>
-        <md-button class="md-primary" :disabled="!selected_engine.connected" @click="expand(selected_engine)">
+        <md-button class="md-primary" :disabled="!selected_engine.connected" @click="expand_published_plugins(selected_engine)">
+          <md-icon>autorenew</md-icon> Published Plugins
+        </md-button>
+        <md-button class="md-primary" :disabled="!selected_engine.connected" @click="expand_processes(selected_engine)">
           <md-icon>autorenew</md-icon> Show Processes
         </md-button>
         <md-menu>
@@ -125,25 +140,46 @@
           <md-divider></md-divider>
           <ul>
             <li v-show="selected_engine.plugin_processes" v-for="p in selected_engine.plugin_processes" :key="p.pid">
-              &nbsp;&nbsp;
-              {{p.name}} (#{{p.pid}})
-              <md-button @click.stop="kill(selected_engine, p)" class="md-icon-button md-accent">
+             
+              <span>{{p.name}} (#{{p.pid}})</span>
+              <md-button @click.stop="kill(selected_engine, p)" class="md-icon-button md-accent small-icon-button">
                 <md-icon>clear</md-icon>
               </md-button>
             </li>
-            <li v-if="!selected_engine.plugin_processes">
+            <li class="menu-item" v-if="!selected_engine.plugin_processes">
               <md-button>
                 <div class="loading loading-lg"></div>
               </md-button>
             </li>
-            <li :disabled="true" v-if="selected_engine.plugin_num>1">
+            <!-- <li :disabled="true" v-if="selected_engine.plugin_num>1">
               <span>&nbsp;&nbsp;{{selected_engine.plugin_num}} Running Plugins</span>
               <md-button @click.stop="kill(selected_engine)" class="md-icon-button md-accent">
                 <md-icon>clear</md-icon>
               </md-button>
+            </li> -->
+          </ul>
+        </div>
+
+        <div v-if="selected_engine.connected && selected_engine.show_published_plugins">
+          <md-divider></md-divider>
+          <ul>
+            <li v-show="selected_engine.published_plugins" v-for="p in selected_engine.published_plugins" :key="p.id">
+              <md-button @click.stop="loadPublishedPlugin(selected_engine, p)" style="text-transform: none;" class="md-primary">
+                <md-icon v-if="p.require_token">vpn_key</md-icon>
+                {{p.name}}  
+                <md-icon>cloud_download</md-icon>
+              </md-button>
+              <md-button @click.stop="unPublishPlugin(selected_engine, p)" v-if="selected_engine.role==='admin'" class="md-icon-button md-accent small-icon-button">
+                <md-icon>clear</md-icon>
+              </md-button>
+            </li>
+            <li v-if="!selected_engine.published_plugins">
+              <md-button>
+                <div class="loading loading-lg"></div>
+              </md-button>
             </li>
           </ul>
-          </div>
+        </div>
       </md-dialog-content>
       <md-dialog-actions>
         <md-button class="md-primary" @click="showEngineInfoDialog=false">OK</md-button>
@@ -157,7 +193,7 @@
 
 export default {
   name: 'engine-control-panel',
-  props: ['engineManager'],
+  props: ['engineManager', 'pluginManager'],
   data(){
     return {
       engine_url: 'http://127.0.0.1:9527',
@@ -168,7 +204,9 @@ export default {
       selected_engine: null,
       show_sys_info: false,
       showAddEngineDialog: false,
-      url_type: 'localhost'
+      url_type: 'localhost',
+      engine_role: 'admin',
+      setting_changed: false
     }
   },
   created(){
@@ -186,6 +224,7 @@ export default {
   },
   methods: {
     showDialog(config){
+      this.setting_changed = false
       if(!config.engine){
         this.showEngineInfoDialog = false
         this.showAddEngineDialog  = config.show
@@ -199,39 +238,81 @@ export default {
     forceUpdate(){
       this.$forceUpdate()
     },
-    expand(engine){
+    expand_processes(engine){
       engine.show_processes = true
+      engine.show_published_plugins = false
       this.$forceUpdate()
-      this.update(engine)
+      this.updateStatus(engine)
     },
-    hide(engine){
+    expand_published_plugins(engine){
+      engine.show_processes = false
+      engine.show_published_plugins = true
+      this.$forceUpdate()
+      this.updatePublishedPlugins(engine)
+    },
+    hide_processes(engine){
       engine.show_processes = false
       this.$forceUpdate()
     },
-    update(engine){
+    hide_published_plugins(engine){
+      engine.show_published_plugins = false
+      this.$forceUpdate()
+    },
+    updateStatus(engine){
       engine.plugin_processes = null
       this.$forceUpdate()
       engine.updateEngineStatus().then(()=>{
         this.$forceUpdate()
       });
     },
+    updatePublishedPlugins(engine){
+      engine.published_plugins = null
+      this.$forceUpdate()
+      engine.getPublishedPlugins().then(()=>{
+        this.$forceUpdate()
+      });
+    },
     kill(engine, p){
       engine.killPluginProcess(p).then(()=>{
-        this.update(engine)
+        this.updateStatus(engine)
       });
+    },
+    loadPublishedPlugin(engine, p){
+      const plugin_token = prompt('Plugin token?')
+      console.log('====================================load published=', p)
+      engine.getPublicationInfo({publish_id: p.publish_id, token: plugin_token}).then(async (ret)=>{
+        if(ret && ret.success){
+          console.log('=====================================', ret.plugin_list)
+          ret.plugin_list = ret.plugin_list || []
+          for(let p of ret.plugin_list){
+            await this.pluginManager.reloadPlugin({code: p.code}, {id: p.id, publish_id: p.publish_id, engine: engine.url, plugin_token: plugin_token})
+          }
+          
+        }
+        this.$forceUpdate()
+      });
+    },
+    unPublishPlugin(engine, p){
+      engine.unpublishPlugin({publish_id: p.publish_id}).then(()=>{
+        this.updatePublishedPlugins(engine)
+      })
     },
     showAddEngine(){
       this.showAddEngineDialog = true
     },
-    hideAddEngine(){
+    hide_processesAddEngine(){
       this.showAddEngineDialog = false
     },
     addEngine(){
+      let token = null
+      if(this.engine_role === 'admin'){
+        token = this.connection_token
+      }
       if(this.url_type === 'localhost'){
-        this.engineManager.addEngine({type: 'default', name: this.local_engine_url,  url: this.local_engine_url, token: this.connection_token})
+        this.engineManager.addEngine({type: 'default', role: this.engine_role, name: this.local_engine_url,  url: this.local_engine_url, token: token})
       }
       else{
-        this.engineManager.addEngine({type: 'default', name:this.engine_url,  url: this.engine_url, token: this.connection_token})
+        this.engineManager.addEngine({type: 'default', role: this.engine_role, name:this.engine_url,  url: this.engine_url, token: token})
       }
     },
     removeEngine(engine){
@@ -276,5 +357,12 @@ export default {
 
 .platform-info>p{
  margin: 3px;
+}
+
+.small-icon-button {
+  width: 24px!important;
+  min-width: 24px!important;
+  height: 24px!important;
+  margin: 0 2px;
 }
 </style>

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -279,10 +279,8 @@ export default {
     },
     loadPublishedPlugin(engine, p){
       const plugin_token = prompt('Plugin token?')
-      console.log('====================================load published=', p)
       engine.getPublicationInfo({publish_id: p.publish_id, token: plugin_token}).then(async (ret)=>{
         if(ret && ret.success){
-          console.log('=====================================', ret.plugin_list)
           ret.plugin_list = ret.plugin_list || []
           for(let p of ret.plugin_list){
             await this.pluginManager.reloadPlugin({code: p.code}, {id: p.id, publish_id: p.publish_id, engine: engine.url, plugin_token: plugin_token})

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -169,7 +169,7 @@
                 {{p.name}}  
                 <md-icon>cloud_download</md-icon>
               </md-button>
-              <md-button @click.stop="unPublishPlugin(selected_engine, p)" v-if="selected_engine.role==='admin'" class="md-icon-button md-accent small-icon-button">
+              <md-button @click.stop="unPublishPlugin(selected_engine, p)" v-if="selected_engine.role==='admin'" class="md-icon-button md-accent big-icon-button">
                 <md-icon>clear</md-icon>
               </md-button>
             </li>
@@ -283,7 +283,9 @@ export default {
         if(ret && ret.success){
           ret.plugin_list = ret.plugin_list || []
           for(let p of ret.plugin_list){
-            await this.pluginManager.reloadPlugin({code: p.code}, {id: p.id, publish_id: p.publish_id, engine: engine.url, plugin_token: plugin_token})
+            await this.pluginManager.reloadPlugin({code: p.code}, {id: p.id, publish_id: p.publish_id, engine: engine.url, plugin_token: plugin_token}).then(()=>{
+              this.$forceUpdate()
+            })
           }
           
         }
@@ -362,5 +364,10 @@ export default {
   min-width: 24px!important;
   height: 24px!important;
   margin: 0 2px;
+}
+
+.big-icon-button {
+  width: 48px;
+  height: 48px;
 }
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1428,7 +1428,6 @@ export default {
       }
     },
     async publishPlugin(plugin){
-      console.log('x-==============================', plugin,plugin.config.publish_id)
       assert(this.publish_config.engine)
       const engine = this.em.getEngineByUrl(this.publish_config.engine)
       assert(engine, 'engine not found')
@@ -1443,7 +1442,6 @@ export default {
         const p = Object.values(this.pm.plugins).filter((p)=>{p.name === plugin_config_dependencies[i].name})[0] || plugin_config_dependencies[i]
         plugin_config_dependencies[i] = {id: p.id, name: p.name, code: p.code}
       }
-      console.log('===========publishing', {id: plugin.id, publish_id: publish_id, name: plugin.name, plugin_list: plugin_config_dependencies})
       const ret = await engine.publishPlugin({id: plugin.id, publish_id: publish_id, name: plugin.name, plugin_list: plugin_config_dependencies})
       if(ret && ret.success){
         plugin.config.publish_id = ret.publish_id

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -144,7 +144,7 @@ export default {
         }
         this.codeValue = this.editor.getValue()
         this.$emit('input', this.codeValue)
-        this.window.plugin_manager.savePlugin({pluginId: this.pluginId, code: this.codeValue, tag: this.window.plugin && this.window.plugin.tag}).then((config)=>{
+        this.window.plugin_manager.savePlugin({pluginId: this.pluginId, code: this.codeValue, tag: this.window.plugin && this.window.plugin.tag, publish_id: this.window.plugin && this.window.plugin.publish_id}).then((config)=>{
           // this.window.data._id = config._id
           // this.window.plugin._id = config._id
           // this.window.plugin.config._id= config._id

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -1139,13 +1139,13 @@ DynamicPlugin.prototype._requestRemote =
        Plugin.prototype._requestRemote = function() {
     var me = this;
     this._site.onRemoteUpdate(function(){
+        me._disconnected = false
+        me.initializing = false
+        me._updateUI()
         me.remote = me._site.getRemote();
         me.api = me.remote;
         me.api.__jailed_type__ = 'plugin_api';
         me.api.__id__ = me.id;
-        me._disconnected = false
-        me.initializing = false
-        me._updateUI()
         me._connect.emit();
     });
 
@@ -1232,16 +1232,18 @@ DynamicPlugin.prototype.terminate =
     }
 
     try {
-      if(this.api && this.api.exit && typeof this.api.exit == 'function'){
-        await this.api.exit()
+      if(this.config.engine && this.config.engine.role === 'admin'){
+        if(this.api && this.api.exit && typeof this.api.exit == 'function'){
+          await this.api.exit()
+        }
       }
     } catch (e) {
       console.error('error occured when terminating the plugin',e)
     }
     finally{
       this._set_disconnected()
-      if(this._site) {this._site.disconnect(); this._site = null }
-      if(this._connection) {this._connection.disconnect(); this._connection = null }
+      if(this._site) {this._site.disconnect(); }
+      if(this._connection) {this._connection.disconnect();}
     }
 
 }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1058,6 +1058,7 @@ export class PluginManager {
   }
 
   loadPlugin(template, rplugin) {
+    template.engine = null
     template = _clone(template)
     this.validatePluginConfig(template)
     //generate a random id for the plugin
@@ -1397,6 +1398,7 @@ export class PluginManager {
   register(plugin, config) {
     try {
       if(!plugin) throw "Plugin not found."
+      config.engine = null
       config = _clone(config)
       config.name = config.name || plugin.name
       config.show_panel = config.show_panel || false

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -811,7 +811,6 @@ export class PluginManager {
         }
         this.unloadPlugin(template, true)
         let p
-        console.log('==========================', template, rplugin)
 
         if (template.type === 'window' || template.type === 'web-python-window') {
           p = this.preLoadPlugin(template, rplugin)
@@ -1101,7 +1100,6 @@ export class PluginManager {
       tconfig.workspace = this.selected_workspace
       tconfig.plugin_token = rplugin && rplugin.plugin_token
       const _interface = _.assign({TAG: tconfig.tag, WORKSPACE: this.selected_workspace, ENGINE_URL: config.engine && config.engine.url}, this.imjoy_api)
-      console.log('=============================================xxx', tconfig, _interface, this.fm.api)
       const plugin = new DynamicPlugin(tconfig, _interface, this.fm.api)
       plugin.whenConnected(() => {
         if (!plugin.api) {

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -86,7 +86,7 @@ describe('ImJoy.vue', async () => {
 
   it('should load the new web-worker plugin', async () => {
     const code = _.clone(WEB_WORKER_PLUGIN_TEMPLATE)
-    const plugin = await pm.reloadPlugin({_id: 'new plugin', tag: null, name:'new plugin', code: code})
+    const plugin = await pm.reloadPlugin({code: code})
     expect(plugin.name).to.equal('Untitled Plugin')
     expect(plugin.type).to.equal('web-worker')
     expect(typeof plugin.api.run).to.equal('function')
@@ -96,7 +96,7 @@ describe('ImJoy.vue', async () => {
 
   it('should load the new window plugin', async () => {
     const code = _.clone(WINDOW_PLUGIN_TEMPLATE)
-    const plugin = await pm.reloadPlugin({_id: 'new plugin', tag: null, name:'new plugin', code: code})
+    const plugin = await pm.reloadPlugin({code: code})
     expect(plugin.name).to.equal('Untitled Plugin')
     expect(plugin.type).to.equal('window')
     expect(typeof plugin.api.run).to.equal('function')
@@ -106,7 +106,7 @@ describe('ImJoy.vue', async () => {
 
   // it('should load the new native-python plugin', async () => {
   //   const code = _.clone(NATIVE_PYTHON_PLUGIN_TEMPLATE)
-  //   const plugin = await vm.pm.reloadPlugin({_id: 'new plugin', tag: null, name:'new plugin', code: code})
+  //   const plugin = await vm.pm.reloadPlugin({code: code})
   //   expect(plugin.name).to.equal('Untitled Plugin')
   //   expect(plugin.type).to.equal('native-python')
   //   expect(typeof plugin.api.run).to.equal('function')
@@ -115,7 +115,7 @@ describe('ImJoy.vue', async () => {
 
   it('should load the new web-python plugin', async () => {
     const code = _.clone(WEB_PYTHON_PLUGIN_TEMPLATE)
-    const plugin = await pm.reloadPlugin({_id: 'new plugin', tag: null, name:'new plugin', code: code})
+    const plugin = await pm.reloadPlugin({code: code})
     expect(plugin.name).to.equal('Untitled Plugin')
     expect(plugin.type).to.equal('web-python')
     expect(typeof plugin.api.run).to.equal('function')
@@ -125,7 +125,7 @@ describe('ImJoy.vue', async () => {
 
   it('should load the new web-python-window plugin', async () => {
     const code = _.clone(WEB_PYTHON_WINDOW_PLUGIN_TEMPLATE)
-    const plugin = await pm.reloadPlugin({_id: 'new plugin', tag: null, name:'new plugin', code: code})
+    const plugin = await pm.reloadPlugin({code: code})
     expect(plugin.name).to.equal('Untitled Plugin')
     expect(plugin.type).to.equal('web-python-window')
     expect(typeof plugin.api.run).to.equal('function')
@@ -159,18 +159,18 @@ describe('ImJoy.vue', async () => {
     let pluginw
     before(function(done){
       this.timeout(20000)
-      pm.reloadPlugin({_id: 'new plugin 1', tag: null, name:'new plugin1', code: _.clone(TEST_WEB_WORKER_PLUGIN_1)}).then((p1)=>{
+      pm.reloadPlugin({code: _.clone(TEST_WEB_WORKER_PLUGIN_1)}).then((p1)=>{
         plugin1 = p1
         expect(plugin1.name).to.equal('Test Web Worker Plugin 1')
         expect(plugin1.type).to.equal('web-worker')
         expect(typeof plugin1.api.run).to.equal('function')
-        pm.reloadPlugin({_id: 'new plugin 2', tag: null, name:'new plugin2', code: _.clone(TEST_WEB_WORKER_PLUGIN_2)}).then((p2)=>{
+        pm.reloadPlugin({code: _.clone(TEST_WEB_WORKER_PLUGIN_2)}).then((p2)=>{
           plugin2 = p2
           expect(plugin2.name).to.equal('Test Web Worker Plugin 2')
           expect(plugin2.type).to.equal('web-worker')
           expect(typeof plugin2.api.run).to.equal('function')
 
-          pm.reloadPlugin({_id: 'new window plugin', tag: null, name:'new window plugin', code: _.clone(TEST_WINDOW_PLUGIN_1)}).then((pw)=>{
+          pm.reloadPlugin({code: _.clone(TEST_WINDOW_PLUGIN_1)}).then((pw)=>{
             pluginw = pw
             expect(pluginw.name).to.equal('Test Window Plugin')
             expect(pluginw.type).to.equal('window')


### PR DESCRIPTION
Plugins running on a remote plugin engine can be shared with users. 
 * Two roles are defined for connecting to an engine: `user` and `admin`. 
 * When a client connect to the engine, these two roles can be choose, the user can connect to an engine without the connection token, and they can access the published plugins.
 * `admin` is connected to the engine with the connection token, can any plugin code and access all the resources and imjoy api functions (e.g. `api.requestUploadUrl`). Importantly, a published plugin is started by the admin, such that the plugin can prepare for itself and allocate resources. 
 * `user` is connected without connection token, and can connect to published plugins (without install and execute). They can only call exported plugin api functions which are already running. Since most of the `api.xxx` functions will go through the client, and the client is not connect with a connection token, therefore, they cannot execute new code, cannot access the engine file system, request new download/upload url. However, these resources can be prepared when the admin setup the plugin.
 * when publishing a plugin, an access token can be generated, and later encoded into a sharable url to send it to the user.
