### PR TITLE
Fix plugin reload

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.39",
+  "version": "0.9.45",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.45",
+  "version": "0.9.46",
   "private": true,
   "description": "ImJoy -- deploying deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -127,7 +127,7 @@
             <li v-show="selected_engine.plugin_processes" v-for="p in selected_engine.plugin_processes" :key="p.pid">
               &nbsp;&nbsp;
               {{p.name}} (#{{p.pid}})
-              <md-button @click.stop="kill(selected_engine, p)" class="md-icon-button md-accent">
+              <md-button @click.stop="kill(selected_engine, p)" class="md-icon-button md-accent small-icon-button">
                 <md-icon>clear</md-icon>
               </md-button>
             </li>
@@ -137,9 +137,8 @@
               </md-button>
             </li>
             <li :disabled="true" v-if="selected_engine.plugin_num>1">
-              <span>&nbsp;&nbsp;{{selected_engine.plugin_num}} Running Plugins</span>
-              <md-button @click.stop="kill(selected_engine)" class="md-icon-button md-accent">
-                <md-icon>clear</md-icon>
+              <md-button @click.stop="kill(selected_engine)" class="md-accent ">
+                <md-icon>clear</md-icon> Kill All ({{selected_engine.plugin_num}} Running Plugins)
               </md-button>
             </li>
           </ul>
@@ -276,5 +275,11 @@ export default {
 
 .platform-info>p{
  margin: 3px;
+}
+
+.small-icon-button{
+  width: 22px!important;
+  min-width: 22px!important;
+  height: 22px!important;
 }
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -913,10 +913,10 @@ export default {
     }
     else {
       this.startImJoy().then(()=>{
-        /* global gtag window */
-        if(gtag){
+        /* global window */
+        if(window.gtag){
           // CAREFUL: DO NOT SEND ANY QUERY STRING, ONLY LOCATION AND PATH
-          gtag('config', 'UA-134837258-1', {'page_location': location.href.split('#')[0], 'page_path': '/#/app'})
+          window.gtag('config', 'UA-134837258-1', {'page_location': location.href.split('#')[0], 'page_path': '/#/app'})
         }
       })
     }

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1978,6 +1978,10 @@ export default {
   }
 }
 
+#engine-file-dialog{
+  z-index: 999;
+}
+
 @media screen and (max-height: 900px) {
   .plugin-dialog {
     max-height: 100%;

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -236,10 +236,10 @@
                 <md-menu-item @click="editPlugin(plugin.id)">
                   <md-icon>edit</md-icon>Edit
                 </md-menu-item>
-                <md-menu-item @click="pm.reloadPlugin(plugin.config)">
+                <md-menu-item @click="reloadPlugin(plugin.config)">
                   <md-icon>autorenew</md-icon>Reload
                 </md-menu-item>
-                <md-menu-item @click="pm.unloadPlugin(plugin)">
+                <md-menu-item @click="unloadPlugin(plugin)">
                   <md-icon>clear</md-icon>Terminate
                 </md-menu-item>
                 <md-menu-item v-if="plugin.config.origin" @click="updatePlugin(plugin.id)">
@@ -264,7 +264,7 @@
               </md-menu-content>
             </md-menu>
 
-            <md-button class="joy-run-button" :class="plugin.running?'md-accent':(plugin._disconnected && plugin.type === 'native-python'? 'disconnected-plugin': 'md-primary')" :disabled="plugin._disconnected && plugin.type != 'native-python'" @click="plugin._disconnected?connectPlugin(plugin):runOp(plugin.ops[plugin.name])">
+            <md-button class="joy-run-button" :class="plugin.running?'busy-plugin':(plugin._disconnected && plugin.type === 'native-python'? 'md-accent': 'md-primary')" :disabled="plugin._disconnected && plugin.type != 'native-python'" @click="plugin._disconnected?connectPlugin(plugin):runOp(plugin.ops[plugin.name])">
               {{plugin.type === 'native-python'? plugin.name + ' 🚀': ( plugin.type === 'web-python' || plugin.type === 'web-python-window' ? plugin.name + ' 🐍': plugin.name) }}
             </md-button>
 
@@ -319,10 +319,10 @@
                   <md-menu-item @click="editPlugin(plugin.id)">
                     <md-icon>edit</md-icon>Edit
                   </md-menu-item>
-                  <md-menu-item @click="pm.reloadPlugin(plugin.config)">
+                  <md-menu-item @click="reloadPlugin(plugin.config)">
                     <md-icon>autorenew</md-icon>Reload
                   </md-menu-item>
-                  <md-menu-item @click="pm.unloadPlugin(plugin)">
+                  <md-menu-item @click="unloadPlugin(plugin)">
                     <md-icon>clear</md-icon>Terminate
                   </md-menu-item>
                   <md-menu-item v-if="plugin.config.origin" @click="updatePlugin(plugin.id)">
@@ -334,7 +334,7 @@
                 </md-menu-content>
               </md-menu>
 
-              <md-button class="joy-run-button" :class="plugin.running?'md-accent':(plugin._disconnected && plugin.type === 'native-python'? 'disconnected-plugin': '')" :disabled="plugin.type != 'native-python' || !plugin._disconnected" @click="connectPlugin(plugin)">
+              <md-button class="joy-run-button" :class="plugin.running? 'busy-plugin':(plugin._disconnected && plugin.type === 'native-python'? 'md-accent' : '')" :disabled="plugin.type != 'native-python' || !plugin._disconnected" @click="connectPlugin(plugin)">
                 {{plugin.type === 'native-python'? plugin.name + ' 🚀': plugin.name}}
               </md-button>
               <md-button class="md-icon-button" :disabled="true">
@@ -1449,6 +1449,16 @@ export default {
         alert('Origin not found for this plugin.')
       }
     },
+    reloadPlugin(config){
+      this.pm.reloadPlugin(config).finally(()=>{
+        this.$forceUpdate()
+      })
+    },
+    unloadPlugin(plugin){
+      this.pm.unloadPlugin(plugin).finally(()=>{
+        this.$forceUpdate()
+      })
+    },
     editPlugin(pid) {
       const plugin = this.pm.plugins[pid]
       const pconfig = plugin.config
@@ -2160,7 +2170,7 @@ button.md-speed-dial-target {
   margin: 1px;
 }
 
-.disconnected-plugin{
+.busy-plugin{
   color: orange!important;
 }
 

--- a/web/src/engineManager.js
+++ b/web/src/engineManager.js
@@ -183,12 +183,14 @@ export class Engine {
             //wait for 10s to see if it recovers
             this.connection_lost_timer = setTimeout(() => {
               this.showMessage('Timeout, connection failed to recover.')
-              this.socket = null
-              this.connected = false
-              this.event_bus.$emit('engine_disconnected', this)
-              this.connection = 'Disconnected.'
-              this.update_ui_callback()
-            }, 10000)
+              if(this.connected){
+                this.socket = null
+                this.connected = false
+                this.event_bus.$emit('engine_disconnected', this)
+                this.connection = 'Disconnected.'
+                this.update_ui_callback()
+              }
+            }, 5000)
           }
         });
     })

--- a/web/src/engineManager.js
+++ b/web/src/engineManager.js
@@ -10,6 +10,7 @@ export class Engine {
     this.activate = false
     this.connection = 'Disconnected'
     this.client_id = client_id
+    this.socket_id = null
     this.config = config
     this.id = this.config.id
     this.name = this.config.name || this.config.url
@@ -99,9 +100,11 @@ export class Engine {
 
         socket.on('connect', () => {
           clearTimeout(timer)
-          if(this.connection_lost_timer){
+          if(this.connection_lost_timer && this.socket_id === socket.id){
             clearTimeout(this.connection_lost_timer)
             this.connection_lost_timer = null
+            this.showMessage(`Connection to ${this.name} has been recovered`)
+            return
           }
           socket.emit('register_client', {id: this.client_id, token: token, base_url: url, session_id: this.engine_session_id}, (ret)=>{
             if(ret && ret.success){
@@ -109,6 +112,7 @@ export class Engine {
                 this.engine_info = ret.engine_info || {}
                 this.engine_info.api_version = this.engine_info.api_version || '0.1.0'
                 this.socket = socket
+                this.socket_id = socket.id
                 this.connected = true
                 this.connected_url_token_ = url + token
                 //this.show_engine_callback(false, this)

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -567,9 +567,8 @@ var SocketioConnectionWeb = function() {
         // console.log('message_to_plugin_'+this.id, {type: 'message', data: data})
       }
       else{
-        console.error('socketio disconnected.')
+        throw 'socketio disconnected.'
       }
-
     }
 
 
@@ -1223,7 +1222,6 @@ DynamicPlugin.prototype.whenFailed =
 DynamicPlugin.prototype.whenConnected =
        Plugin.prototype.whenConnected = function(handler) {
     this._connect.whenEmitted(handler);
-
 }
 
 

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -791,6 +791,7 @@ export class PluginManager {
         const template = this.parsePluginCode(pconfig.code, pconfig)
         template._id = pconfig._id
         template.engine_mode = pconfig.engine_mode
+        template.engine = null
 
         if(template.type === 'collection'){
           return

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -761,7 +761,7 @@ export class PluginManager {
     })
   }
 
-  async unloadPlugin(_plugin, temp_remove){
+  unloadPlugin(_plugin, temp_remove){
     const name = _plugin.name
     for (let k in this.plugins) {
       if (this.plugins.hasOwnProperty(k)) {
@@ -775,16 +775,9 @@ export class PluginManager {
               plugin._unloaded = true
               this.unregister(plugin)
               if (typeof plugin.terminate === 'function') {
-                try{
-                  await plugin.terminate()
-                }
-                catch(e){
-                  console.error(e)
-                }
-                finally{
+                plugin.terminate().then(()=>{
                   this.update_ui_callback()
-                }
-                
+                })
               }
             } catch (e) {
               console.error(e)
@@ -907,7 +900,7 @@ export class PluginManager {
             await this.reloadPlugin(plugin)
           }
           else{
-            await this.unloadPlugin(plugin, false)
+            this.unloadPlugin(plugin, false)
           }
         }
       }
@@ -1662,9 +1655,9 @@ export class PluginManager {
       } else {
         const window_config = this.registered.windows[wconfig.type]
         if (!window_config) {
-          console.error('no plugin registered for window type: ', wconfig.type)
-          reject('no plugin registered for window type: ', wconfig.type)
-          throw 'no plugin registered for window type: ', wconfig.type
+          console.error('no plugin registered for window type: ' + wconfig.type, this.registered.windows)
+          reject('no plugin registered for window type: ' + wconfig.type)
+          throw 'no plugin registered for window type: '+ wconfig.type
         }
         const pconfig = wconfig
         //generate a new window id


### PR DESCRIPTION
This is an important PR to fix a few plugin engine bugs: 1) When there are multiple plugin engines, the plugin will run once for each plugin engine. 2) When reload the plugin, the termination process is not properly awaited. 3) kill all plugin was not working