### PR TITLE
Escape html in dialogs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -257,7 +257,13 @@ For HTML:
 
 **Example**
 ```javascript
-const anwser = await api.confirm('Do you want to delete these files?')
+const confirmation = await api.confirm('Do you want to delete these files?')
+if(confirmation){
+  delete_file()
+}
+else{
+  console.log('User cancelled file deletion.')
+}
 ```
 <!--****[TODO] add example **-->
 
@@ -1209,17 +1215,20 @@ It contains the following fields:
 
 **Examples**
 
-Example will show either the specified file-name or an error message that the
+Example will show either the specified file-name or an message that the
 user canceled or that the plugin engine was not running.
 
 ```javascript
-try{
-  const ret = await api.showFileDialog({root: '/', uri_type: 'url'})
+
+const ret = await api.showFileDialog({root: '/', uri_type: 'url'})
+if(ret){
   await api.alert("Selected file " + ret.url)
 }
-catch(e){
-  await api.alert("Error: "+e.toString())
-};
+else{
+  await api.alert("User cancelled file selection.")
+}
+
+
 ```
 <!--**[TODO]: update this example to new api**-->
 [Try yourself >>](https://imjoy.io/#/app?plugin=oeway/ImJoy-Demo-Plugins:showFileDialog&w=examples)

--- a/docs/api.md
+++ b/docs/api.md
@@ -982,6 +982,7 @@ Upload a file to a upload url.
 * **config**. Object (JavaScript) or dictionary (Python).
 It contains the following fields:
   - **url** : String. The upload url to be uploaded (get from `api.requestUploadUrl`).
+  - **method** (optional): String. The request method, default value: 'POST'.
 
 **Returns**
 * **fileInfo**. Object (JavaScript) or dictionary (Python). Information about the uploaded file.
@@ -1013,6 +1014,8 @@ Upload a file to a upload url.
 * **config**. Object (JavaScript) or dictionary (Python).
 It contains the following fields:
   - **url** : String. The url to the remote file (get from `api.getFileUrl`).
+  - **method** (optional): String. The request method, default value: 'GET'.
+  - **responseType** (optional): String. The default response type, default value: 'blob'. 
 
 **Returns**
 * **fileInfo**. Object (JavaScript) or dictionary (Python). The downloaded file.

--- a/docs/api.md
+++ b/docs/api.md
@@ -855,7 +855,7 @@ Set a callback function to the current plugin which will be called when terminat
 
 **Arguments**
 
-* **callback_func**: String. The callback function to be called during plugin termination.
+* **callback_func**: Function. The callback function to be called during plugin termination.
 
 
 ### api.progress

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,16 @@ Shows an alert dialog with a message to the user.
 **Arguments**
 <!--****[TODO] add instructions about customizable parameters **-->
 
+For plain text:
+
 * **message**: String. Contains the message to be displayed. HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+
+For HTML:
+
+* **message**: Object. It contains the following fields:
+  - **content**: Contains the question to be displayed. HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+  - **title**: The title of the dialog
+
 
 **Example**
 ```javascript
@@ -199,7 +208,16 @@ Shows a prompt to ask the user input.
 **Arguments**
 <!--****[TODO] add instructions about customizable parameters **-->
 
+For plain text:
+
 * **question**: String. Contains the question to be displayed.  HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+
+For HTML:
+
+* **question**: Object. It contains the following fields:
+  - **content**: Contains the question to be displayed. HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+  - **placeholder**: The default anwser of the question
+  - **title**: The title of the dialog
 
 * **default_anwser** (optional): String. Contains the default anwser to the question.
 
@@ -223,7 +241,15 @@ Shows a confirmation message to the user.
 **Arguments**
 <!--****[TODO] add instructions about customizable parameters **-->
 
+For plain text:
+
 * **question**: String. Contains the question to be displayed.  HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+
+For HTML:
+
+* **question**: Object. It contains the following fields:
+  - **content**: Contains the question to be displayed. HTML tags can be used in the message, but only limited to a restricted set of tags and css, more details can be found [here](api?id=sanitized-html-and-css).
+  - **title**: The title of the dialog
 
 **Returns**
 * **confirmation**: Boolean. True or false.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.47",
+  "version": "0.9.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4292,6 +4292,27 @@
       "requires": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.0.0"
+      }
+    },
+    "create-file-webpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/create-file-webpack/-/create-file-webpack-1.0.2.tgz",
+      "integrity": "sha512-+J6kQTE+Wcobc6gHP8E2zmoeIC+J+p6IXqjFrzoxCl1VYlimWoincPUABAhODuXAJGrZcNZ/Up0PTqq1ISiwvA==",
+      "dev": true,
+      "requires": {
+        "path": "^0.12.7",
+        "write": "^1.0.3"
+      },
+      "dependencies": {
+        "write": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+          "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+          "dev": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        }
       }
     },
     "create-hash": {
@@ -11771,6 +11792,16 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
       "dev": true
+    },
+    "path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
+      "dev": true,
+      "requires": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
     },
     "path-browserify": {
       "version": "0.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.49",
+  "version": "0.9.50",
   "private": true,
   "description": "ImJoy -- deploying deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
     "chromedriver": "^2.38.2",
     "cname-webpack-plugin": "^1.0.3",
     "copy-webpack-plugin": "^4.6.0",
+    "create-file-webpack": "^1.0.2",
     "cross-env": "^5.0.1",
     "cross-spawn": "^5.0.1",
     "css-loader": "^2.1.1",

--- a/web/src/components/FileDialog.vue
+++ b/web/src/components/FileDialog.vue
@@ -310,6 +310,7 @@ export default {
       }
       return new Promise((resolve2, reject2) => {
         if (this.options.uri_type === "path") {
+          // user selected
           this.resolve = path => {
             if (this.options.return_object) {
               resolve2({ path: path, engine: this.selected_engine.url });
@@ -317,9 +318,24 @@ export default {
               resolve2(path);
             }
           };
-          this.reject = reject2;
+          // if user cancelled
+          this.reject = () => {
+            if (this.options.return_object) {
+              resolve2(false);
+            } else {
+              reject2("User cancelled selection.");
+            }
+          };
         } else if (this.options.uri_type === "url") {
-          this.reject = reject2;
+          // if user cancelled
+          this.reject = () => {
+            if (this.options.return_object) {
+              resolve2(false);
+            } else {
+              reject2("User cancelled selection.");
+            }
+          };
+          // user selected
           this.resolve = paths => {
             if (typeof paths === "string") {
               this.getFileUrl(_plugin, {

--- a/web/src/components/FileDialog.vue
+++ b/web/src/components/FileDialog.vue
@@ -420,26 +420,31 @@ export default {
     },
     async remove() {
       let files = [];
-      if (!this.file_tree_selection_info) {
-        throw "no file selected";
+      try {
+        if (!this.file_tree_selection_info) {
+          throw "no file selected";
+        }
+        if (Array.isArray(this.file_tree_selection_info)) {
+          files = this.file_tree_selection_info;
+        } else {
+          files = [this.file_tree_selection_info];
+        }
+        // clear selection
+        this.file_tree_selection = null;
+        this.file_tree_selection_info = null;
+        for (let f of files) {
+          await this.removeFiles(
+            this.selected_engine,
+            f.path,
+            f.target.type,
+            this.options.recursive
+          );
+          this.status_text = `"${f.target.name}" has been removed.`;
+        }
+        this.refreshList();
+      } catch (e) {
+        this.status_text = `Error occured when removing file or folder: ${e}`;
       }
-      if (Array.isArray(this.file_tree_selection_info)) {
-        files = this.file_tree_selection_info;
-      } else {
-        files = [this.file_tree_selection_info];
-      }
-      // clear selection
-      this.file_tree_selection = null;
-      this.file_tree_selection_info = null;
-      for (let f of files) {
-        await this.removeFiles(
-          this.selected_engine,
-          f.path,
-          f.target.type,
-          this.options.recursive
-        );
-      }
-      this.refreshList();
     },
     async downloadFiles() {
       let files = [];

--- a/web/src/components/FileDialog.vue
+++ b/web/src/components/FileDialog.vue
@@ -428,6 +428,9 @@ export default {
       } else {
         files = [this.file_tree_selection_info];
       }
+      // clear selection
+      this.file_tree_selection = null;
+      this.file_tree_selection_info = null;
       for (let f of files) {
         await this.removeFiles(
           this.selected_engine,

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1950,8 +1950,7 @@ export default {
       this.checking = true;
       try {
         const response = await axios.get(
-          "https://raw.githubusercontent.com/oeway/ImJoy/master/web/package.json?" +
-            randId()
+          "https://imjoy.io/version.json?" + randId()
         );
         if (!response || !response.data) {
           this.showMessage("failed to fetch imjoy version information");

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2976,10 +2976,10 @@ export default {
           throw "unsupported prompt arguments";
         }
         this.confirm_config.confirm = () => {
-          resolve();
+          resolve(true);
         };
         this.confirm_config.cancel = () => {
-          reject();
+          resolve(false);
         };
         this.confirm_config.show = true;
       });

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2372,8 +2372,8 @@ export default {
         plugin: plugin,
         plugin_manager: this.pm,
         engine_manager: this.em,
-        w: 20,
-        h: 10,
+        w: 30,
+        h: 40,
         standalone: this.screenWidth < 1200,
         data: {
           name: pconfig.name,
@@ -2390,8 +2390,8 @@ export default {
         config: {},
         plugin_manager: this.pm,
         engine_manager: this.em,
-        w: 20,
-        h: 10,
+        w: 30,
+        h: 40,
         standalone: this.screenWidth < 1200,
         plugin: {},
         data: {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -39,18 +39,6 @@
             >Deploying Deep Learning Made Easy!</span
           >
         </div>
-        <md-snackbar
-          md-position="center"
-          class="md-accent"
-          :md-active.sync="show_snackbar"
-          :md-duration="snackbar_duration"
-        >
-          <span>{{ snackbar_info }}</span>
-          <md-button class="md-accent" @click="show_snackbar = false"
-            >close</md-button
-          >
-        </md-snackbar>
-
         <div class="md-toolbar-section-end">
           <md-button
             class="md-icon-button md-accent"
@@ -779,7 +767,22 @@
         showRemoveConfirmation = false;
       "
     />
+
+    <md-snackbar
+      id="api-snackbar"
+      md-position="center"
+      class="md-accent"
+      :md-active.sync="show_snackbar"
+      :md-duration="snackbar_duration"
+    >
+      <span>{{ snackbar_info }}</span>
+      <md-button class="md-accent" @click="show_snackbar = false"
+        >close</md-button
+      >
+    </md-snackbar>
+
     <md-dialog-alert
+      class="api-dialog"
       :md-active.sync="alert_config.show"
       :md-title="alert_config.title"
       :md-content="alert_config.content"
@@ -787,6 +790,7 @@
     />
 
     <md-dialog-confirm
+      class="api-dialog"
       :md-active.sync="confirm_config.show"
       :md-title="confirm_config.title"
       :md-content="confirm_config.content"
@@ -797,6 +801,7 @@
     />
 
     <md-dialog-prompt
+      class="api-dialog"
       :md-active.sync="prompt_config.show"
       v-model="prompt_config.value"
       :md-title="prompt_config.title"
@@ -847,7 +852,7 @@
             ref="plugin_dialog_joy"
           ></joy>
         </div>
-        <div v-else id="window_dialog_container" class="plugin-iframe">
+        <div v-else id="window-dialog-container" class="plugin-iframe">
           <window
             v-if="plugin_dialog_window_config"
             :w="plugin_dialog_window_config"
@@ -2242,6 +2247,9 @@ export default {
         root: "./",
       })
         .then(selection => {
+          if (!selection) {
+            return;
+          }
           if (!Array.isArray(selection)) {
             selection = [selection];
           }
@@ -2883,7 +2891,7 @@ export default {
             reject,
           ];
         } else if (config.type) {
-          config.window_container = "window_dialog_container";
+          config.window_container = "window-dialog-container";
           config.standalone = true;
           this.plugin_dialog_window_config = null;
           if (config.type.startsWith("imjoy/")) {
@@ -2936,14 +2944,14 @@ export default {
           this.prompt_config.content = escapeHTML(text);
           this.prompt_config.placeholder = defaultText;
           this.prompt_config.cancel_text = "Cancel";
-          this.prompt_config.confirm_text = "Done";
+          this.prompt_config.confirm_text = "OK";
         } else if (typeof text === "object") {
           this.prompt_config.title = text.title;
           this.prompt_config.content =
             sanitizer.sanitizeString(text.content) || "undefined";
           this.prompt_config.placeholder = text.placeholder || null;
           this.prompt_config.cancel_text = text.cancel_text || "Cancel";
-          this.prompt_config.confirm_text = text.confirm_text || "Done";
+          this.prompt_config.confirm_text = text.confirm_text || "OK";
         } else {
           reject("unsupported prompt arguments");
           throw "unsupported prompt arguments";
@@ -2964,13 +2972,13 @@ export default {
           this.confirm_config.title = null;
           this.confirm_config.content = escapeHTML(text);
           this.confirm_config.cancel_text = "Cancel";
-          this.confirm_config.confirm_text = "Done";
+          this.confirm_config.confirm_text = "OK";
         } else if (typeof text === "object") {
           this.confirm_config.title = text.title;
           this.confirm_config.content =
             sanitizer.sanitizeString(text.content) || "undefined";
           this.confirm_config.cancel_text = text.cancel_text || "Cancel";
-          this.confirm_config.confirm_text = text.confirm_text || "Done";
+          this.confirm_config.confirm_text = text.confirm_text || "OK";
         } else {
           reject("unsupported prompt arguments");
           throw "unsupported prompt arguments";
@@ -3090,7 +3098,15 @@ export default {
 }
 
 #engine-file-dialog {
-  z-index: 999;
+  z-index: 12 !important;
+}
+
+.api-dialog {
+  z-index: 13 !important;
+}
+
+#api-snackbar {
+  z-index: 14 !important;
 }
 
 @media screen and (max-height: 900px) {
@@ -3116,9 +3132,10 @@ export default {
   max-height: 900px;
 }
 
-#window_dialog_container {
+#window-dialog-container {
   height: 100%;
   width: 100%;
+  z-index: 11 !important;
 }
 .md-card {
   /* width: 100%; */

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2672,7 +2672,7 @@ export default {
         this.showMessage("Uploading a file to " + config.url);
         let totalLength = null;
         axios({
-          method: "post",
+          method: "post" || config.method,
           url: config.url,
           data: bodyFormData,
           headers: config.headers || { "Content-Type": "multipart/form-data" },
@@ -2723,7 +2723,10 @@ export default {
         this.showMessage("Downloading from " + config.url);
         let totalLength = null;
         axios
-          .get(config.url, {
+          .get({
+            url: config.url,
+            method: config.method || "GET",
+            responseType: config.method || "blob",
             onDownloadProgress: progressEvent => {
               totalLength =
                 totalLength || progressEvent.lengthComputable

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1259,6 +1259,7 @@ import {
   _clone,
   compareVersions,
   HtmlWhitelistedSanitizer,
+  escapeHTML,
 } from "../utils.js";
 
 import { PluginManager } from "../pluginManager.js";
@@ -2910,7 +2911,7 @@ export default {
       console.log("alert: ", text);
       if (typeof text === "string") {
         this.alert_config.title = null;
-        this.alert_config.content = sanitizer.sanitizeString(text);
+        this.alert_config.content = escapeHTML(text);
         this.alert_config.confirm_text = "OK";
       } else if (typeof text === "object") {
         this.alert_config.title = text.title;
@@ -2929,7 +2930,7 @@ export default {
       return new Promise((resolve, reject) => {
         if (typeof text === "string") {
           this.prompt_config.title = null;
-          this.prompt_config.content = sanitizer.sanitizeString(text);
+          this.prompt_config.content = escapeHTML(text);
           this.prompt_config.placeholder = defaultText;
           this.prompt_config.cancel_text = "Cancel";
           this.prompt_config.confirm_text = "Done";
@@ -2958,7 +2959,7 @@ export default {
       return new Promise((resolve, reject) => {
         if (typeof text === "string") {
           this.confirm_config.title = null;
-          this.confirm_config.content = sanitizer.sanitizeString(text);
+          this.confirm_config.content = escapeHTML(text);
           this.confirm_config.cancel_text = "Cancel";
           this.confirm_config.confirm_text = "Done";
         } else if (typeof text === "object") {

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -304,11 +304,6 @@ export default {
           this.window.plugin = {};
         });
     },
-    renumber(content) {
-      const lines = content.split("\n");
-      for (let line of lines) {
-      }
-    },
     reload() {
       assert(this.window.plugin_manager);
 

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -304,6 +304,11 @@ export default {
           this.window.plugin = {};
         });
     },
+    renumber(content) {
+      const lines = content.split("\n");
+      for (let line of lines) {
+      }
+    },
     reload() {
       assert(this.window.plugin_manager);
 

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1244,13 +1244,18 @@ export class PluginManager {
         {
           TAG: tconfig.tag,
           WORKSPACE: this.selected_workspace,
-          ENGINE_URL: config.engine && config.engine.url || undefined,
+          ENGINE_URL: (config.engine && config.engine.url) || undefined,
         },
         this.imjoy_api
       );
       const plugin = new DynamicPlugin(tconfig, _interface, this.fm.api);
-      plugin._log_history.push(`Loading plugin ${plugin.id} (TAG=${_interface.TAG}, WORKSPACE=${_interface.WORKSPACE})`)
-      if(_interface.ENGINE_URL) plugin._log_history.push(`ENGINE_URL=${_interface.ENGINE_URL}`)
+      plugin._log_history.push(
+        `Loading plugin ${plugin.id} (TAG=${_interface.TAG}, WORKSPACE=${
+          _interface.WORKSPACE
+        })`
+      );
+      if (_interface.ENGINE_URL)
+        plugin._log_history.push(`ENGINE_URL=${_interface.ENGINE_URL}`);
       plugin.whenConnected(() => {
         if (!plugin.api) {
           console.error("Error occured when loading plugin.");
@@ -1258,7 +1263,7 @@ export class PluginManager {
           reject("Error occured when loading plugin.");
           throw "Error occured when loading plugin.";
         }
-        plugin._log_history.push(`Plugin connected.`)
+        plugin._log_history.push(`Plugin connected.`);
         if (plugin._unloaded) {
           console.log(
             "WARNING: this plugin is ready but unloaded: " + plugin.id
@@ -1276,7 +1281,7 @@ export class PluginManager {
           this.registerExtension(template.extensions, plugin);
         }
         if (plugin.config.resumed && plugin.api.resume) {
-          plugin._log_history.push(`Resuming plugin.`)
+          plugin._log_history.push(`Resuming plugin.`);
           plugin.api
             .resume()
             .then(() => {
@@ -1295,7 +1300,7 @@ export class PluginManager {
               });
             });
         } else if (plugin.api.setup) {
-          plugin._log_history.push(`Setting up plugin.`)
+          plugin._log_history.push(`Setting up plugin.`);
           plugin.api
             .setup()
             .then(() => {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1070,6 +1070,7 @@ export class PluginManager {
         config.tag = tag || null;
       } else {
         const pluginComp = parseComponent(code);
+        console.log("=======================================", pluginComp);
         config = JSON.parse(pluginComp.config[0].content);
         config.scripts = [];
         for (let i = 0; i < pluginComp.script.length; i++) {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1244,11 +1244,13 @@ export class PluginManager {
         {
           TAG: tconfig.tag,
           WORKSPACE: this.selected_workspace,
-          ENGINE_URL: config.engine && config.engine.url,
+          ENGINE_URL: config.engine && config.engine.url || undefined,
         },
         this.imjoy_api
       );
       const plugin = new DynamicPlugin(tconfig, _interface, this.fm.api);
+      plugin._log_history.push(`Loading plugin ${plugin.id} (TAG=${_interface.TAG}, WORKSPACE=${_interface.WORKSPACE})`)
+      if(_interface.ENGINE_URL) plugin._log_history.push(`ENGINE_URL=${_interface.ENGINE_URL}`)
       plugin.whenConnected(() => {
         if (!plugin.api) {
           console.error("Error occured when loading plugin.");
@@ -1256,6 +1258,7 @@ export class PluginManager {
           reject("Error occured when loading plugin.");
           throw "Error occured when loading plugin.";
         }
+        plugin._log_history.push(`Plugin connected.`)
         if (plugin._unloaded) {
           console.log(
             "WARNING: this plugin is ready but unloaded: " + plugin.id
@@ -1273,6 +1276,7 @@ export class PluginManager {
           this.registerExtension(template.extensions, plugin);
         }
         if (plugin.config.resumed && plugin.api.resume) {
+          plugin._log_history.push(`Resuming plugin.`)
           plugin.api
             .resume()
             .then(() => {
@@ -1291,6 +1295,7 @@ export class PluginManager {
               });
             });
         } else if (plugin.api.setup) {
+          plugin._log_history.push(`Setting up plugin.`)
           plugin.api
             .setup()
             .then(() => {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1839,7 +1839,7 @@ export class PluginManager {
         wconfig.window_type = wconfig.type;
 
         if (
-          wconfig.window_container === "window_dialog_container" &&
+          wconfig.window_container === "window-dialog-container" &&
           wconfig.render
         ) {
           this.wm.setupCallbacks(wconfig);

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1070,7 +1070,6 @@ export class PluginManager {
         config.tag = tag || null;
       } else {
         const pluginComp = parseComponent(code);
-        console.log("=======================================", pluginComp);
         config = JSON.parse(pluginComp.config[0].content);
         config.scripts = [];
         for (let i = 0; i < pluginComp.script.length; i++) {

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -707,6 +707,12 @@ export function randId() {
     .substr(2, 10);
 }
 
+export function escapeHTML(html) {
+  const escapeEl = document.createElement("textarea");
+  escapeEl.textContent = html;
+  return escapeEl.innerHTML;
+}
+
 // Deep clone
 export function _clone(aObject) {
   if (!aObject) {

--- a/web/vue.config.js
+++ b/web/vue.config.js
@@ -4,6 +4,17 @@ const webpack = require('webpack')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const CnameWebpackPlugin = require('cname-webpack-plugin')
+const CreateFileWebpack = require('create-file-webpack')
+const package_json = require('./package.json')
+
+const version_file = {
+  // path to folder in which the file will be created
+  path: path.join(__dirname, "dist"),
+  // file name
+  fileName: 'version.json',
+  // content of the file
+  content: `{"name": "${package_json.name}", "version": "${package_json.version}", "description": "${package_json.description}"}`
+};
 
 module.exports = {
   runtimeCompiler: true,
@@ -27,6 +38,7 @@ module.exports = {
       exprContextCritical: false
     },
     plugins: [
+      new CreateFileWebpack(version_file),
       new CnameWebpackPlugin({
         domain: process.env.DEPLOY_MODE === 'dev' ? 'dev.imjoy.io' : 'imjoy.io',
       }),


### PR DESCRIPTION
Currently, the alert/confirm/prompt are in HTML mode by default, this PR will put them in plain text mode, and can be switched to html mode by passing an object.

 * Fixed also a bug in the docs about `api.onClose`.

 * Fix dialog order
 * Fixes $124
 * check deployed version number instead of the version on github master
 * return false if user cancelled `api.showFileDialog` and `api.confirm`
