### PR TITLE
Support terminal window in ImJoy

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.56",
+  "version": "0.9.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16921,6 +16921,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "xterm": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/xterm/-/xterm-3.13.1.tgz",
+      "integrity": "sha512-QtQjqZ3JVgIQHK6cBKIGSHY36dNs15nQ5+w8i5Pxg5I6nYGyg5HJT79xZyLiZhOoIet00fUQvVXArrOM2R9WNw=="
     },
     "xxhashjs": {
       "version": "0.2.2",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.56",
+  "version": "0.9.60",
   "private": true,
   "description": "ImJoy -- deploying deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",
@@ -33,7 +33,8 @@
     "vue": "^2.5.17",
     "vue-grid-layout": "github:jbaysolutions/vue-grid-layout#9e13ea9",
     "vue-material": "^1.0.0-beta-11",
-    "vue-router": "^3.0.1"
+    "vue-router": "^3.0.1",
+    "xterm": "^3.13.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.1.1",

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -44,6 +44,13 @@
             >
               <md-icon>autorenew</md-icon>
             </md-button>
+            <md-button
+              class="md-icon-button md-primary"
+              v-if="engine.connected"
+              @click.stop="startTerminal(engine)"
+              ><md-icon>code</md-icon></md-button
+            >
+
             <span>{{ engine.name }}</span>
           </md-menu-item>
           <md-menu-item v-else @click.stop="engine.connect(false)">
@@ -174,7 +181,9 @@
             name="connection_token"
           ></md-input>
         </md-field>
-        <p>- engine version: {{ selected_engine.engine_info.version }}</p>
+        <p v-if="selected_engine.connected && selected_engine.engine_info">
+          - engine version: {{ selected_engine.engine_info.version }}
+        </p>
         <div
           v-if="
             selected_engine.connected &&
@@ -399,6 +408,9 @@ export default {
     disconnectEngine(engine) {
       if (engine.connected) engine.disconnect();
       this.$forceUpdate();
+    },
+    startTerminal(engine) {
+      this.$emit("start-terminal", engine);
     },
     showToken(engine) {
       this.engine_url = engine.config.url;

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -208,7 +208,7 @@
           :disabled="!selected_engine.connected"
           @click="expand(selected_engine)"
         >
-          <md-icon>autorenew</md-icon> Show Processes
+          <md-icon>autorenew</md-icon> Processes
         </md-button>
         <md-button
           v-if="selected_engine.connected"
@@ -219,7 +219,7 @@
           class="md-primary"
           :disabled="!selected_engine.connected"
         >
-          <md-icon>code</md-icon> Open Terminal
+          <md-icon>code</md-icon> Terminal
         </md-button>
 
         <md-menu>

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -44,13 +44,6 @@
             >
               <md-icon>autorenew</md-icon>
             </md-button>
-            <md-button
-              class="md-icon-button md-primary"
-              v-if="engine.connected"
-              @click.stop="startTerminal(engine)"
-              ><md-icon>code</md-icon></md-button
-            >
-
             <span>{{ engine.name }}</span>
           </md-menu-item>
           <md-menu-item v-else @click.stop="engine.connect(false)">
@@ -217,6 +210,18 @@
         >
           <md-icon>autorenew</md-icon> Show Processes
         </md-button>
+        <md-button
+          v-if="selected_engine.connected"
+          @click="
+            startTerminal(selected_engine);
+            showEngineInfoDialog = false;
+          "
+          class="md-primary"
+          :disabled="!selected_engine.connected"
+        >
+          <md-icon>code</md-icon> Open Terminal
+        </md-button>
+
         <md-menu>
           <md-button class="md-icon-button" md-menu-trigger>
             <md-icon class="md-primary">more_horiz</md-icon>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2379,7 +2379,7 @@ export default {
         config: {},
         w: 30,
         h: 20,
-        standalone: false, //this.screenWidth < 1200,
+        standalone: this.screenWidth < 1200,
         data: {
           engine: engine,
         },

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -170,7 +170,10 @@
               </md-menu-item>
             </md-menu-content>
           </md-menu>
-          <engine-control-panel :engine-manager="em" />
+          <engine-control-panel
+            :engine-manager="em"
+            @start-terminal="startTerminal"
+          />
           <md-menu>
             <md-button
               v-if="latest_version && !is_latest_version"
@@ -2368,6 +2371,20 @@ export default {
     },
     unloadPlugin(plugin) {
       this.pm.unloadPlugin(plugin);
+    },
+    startTerminal(engine) {
+      const w = {
+        name: "Terminal " + engine.url,
+        type: "imjoy/terminal",
+        config: {},
+        w: 30,
+        h: 20,
+        standalone: false, //this.screenWidth < 1200,
+        data: {
+          engine: engine,
+        },
+      };
+      this.createWindow(w);
     },
     editPlugin(pid) {
       const plugin = this.pm.plugins[pid];

--- a/web/src/components/windows/TerminalWindow.vue
+++ b/web/src/components/windows/TerminalWindow.vue
@@ -63,10 +63,7 @@ export default {
       scrollback: true,
     });
     term.open(this.$refs.terminal_container);
-    term.fit();
-    term.resize(15, 50);
-    // term.toggleFullScreen(true)
-    term.fit();
+    this.fitToscreen()
     term.write("Welcome to ImJoy plugin engine terminal!\r\n");
     this.term = term;
     if (this.engine && this.engine.connected) {

--- a/web/src/components/windows/TerminalWindow.vue
+++ b/web/src/components/windows/TerminalWindow.vue
@@ -11,7 +11,7 @@
 
 <script>
 import { Terminal } from "xterm";
-import style from "xterm/lib/xterm.css";
+import "xterm/lib/xterm.css";
 import * as fullscreen from "xterm/lib/addons/fullscreen/fullscreen";
 import * as fit from "xterm/lib/addons/fit/fit";
 import * as webLinks from "xterm/lib/addons/webLinks/webLinks";
@@ -81,10 +81,10 @@ export default {
     start() {
       this.engine.socket.emit("start_terminal", {}, ret => {
         if (ret && ret.success) {
-          this.term.on("key", (key, ev) => {
+          this.term.on("key", key => {
             this.engine.socket.emit("terminal_input", { input: key });
           });
-          this.term.on("paste", (data, ev) => {
+          this.term.on("paste", data => {
             this.engine.socket.emit("terminal_input", { input: data });
           });
           this.engine.socket.on("terminal_output", data => {

--- a/web/src/components/windows/TerminalWindow.vue
+++ b/web/src/components/windows/TerminalWindow.vue
@@ -1,0 +1,135 @@
+<template>
+  <div class="terminal">
+    <h5 v-if="!engine || !engine.connected || disconnected">{{ status }}</h5>
+    <div
+      ref="terminal_container"
+      :style="{ height: window_height }"
+      class="terminal-window"
+    ></div>
+  </div>
+</template>
+
+<script>
+import { Terminal } from "xterm";
+import style from "xterm/lib/xterm.css";
+import * as fullscreen from "xterm/lib/addons/fullscreen/fullscreen";
+import * as fit from "xterm/lib/addons/fit/fit";
+import * as webLinks from "xterm/lib/addons/webLinks/webLinks";
+import * as search from "xterm/lib/addons/search/search";
+
+function debounce(func, wait_ms) {
+  let timeout;
+  return function(...args) {
+    const context = this;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func.apply(context, args), wait_ms);
+  };
+}
+export default {
+  name: "terminal-window",
+  type: "imjoy/terminal",
+  props: {
+    w: {
+      type: Object,
+      default: function() {
+        return null;
+      },
+    },
+    loaders: {
+      type: Object,
+      default: function() {
+        return null;
+      },
+    },
+  },
+  data() {
+    return {
+      status: "Disconnected",
+      disconnected: false,
+      engine: null,
+      window_height: "500px",
+    };
+  },
+  created() {},
+  mounted() {
+    this.engine = this.w.data.engine;
+    Terminal.applyAddon(fullscreen);
+    Terminal.applyAddon(fit);
+    Terminal.applyAddon(webLinks);
+    Terminal.applyAddon(search);
+    const term = new Terminal({
+      cursorBlink: true,
+      macOptionIsMeta: true,
+      scrollback: true,
+    });
+    term.open(this.$refs.terminal_container);
+    term.fit();
+    term.resize(15, 50);
+    // term.toggleFullScreen(true)
+    term.fit();
+    term.write("Welcome to ImJoy plugin engine terminal!\r\n");
+    this.term = term;
+
+    this.engine.socket.emit("start_terminal", {}, ret => {
+      if (ret && ret.success) {
+        term.on("key", (key, ev) => {
+          this.engine.socket.emit("terminal_input", { input: key });
+        });
+        this.engine.socket.on("terminal_output", function(data) {
+          term.write(data.output);
+        });
+        this.status = "Terminal connected.";
+        this.disconnected = false;
+        this.$forceUpdate();
+      } else {
+        this.status = "Failed to start terminal.";
+        this.disconnected = true;
+        this.$forceUpdate();
+      }
+      const wait_ms = 50;
+      const fit2screen = debounce(this.fitToscreen, wait_ms);
+      window.onresize = fit2screen;
+      this.w.onResize(fit2screen);
+      this.w.onRefresh(fit2screen);
+    });
+  },
+  methods: {
+    fitToscreen() {
+      this.window_height = this.$el.clientHeight + "px";
+      this.$forceUpdate();
+      console.log("===============", this.window_height);
+      this.$nextTick(() => {
+        this.term.fit();
+        console.log(`size: ${this.term.cols} columns, ${this.term.rows} rows`);
+        this.engine.socket.emit("terminal_window_resize", {
+          cols: this.term.cols,
+          rows: this.term.rows,
+        });
+        this.$forceUpdate();
+      });
+    },
+  },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style scoped>
+.terminal {
+  height: 100%;
+  width: 100%;
+}
+.info {
+  color: #4286f4;
+  transition: 0.3s;
+}
+
+.error {
+  color: #f44336;
+  transition: 0.3s;
+}
+
+.terminal-window {
+  width: 100%;
+  display: block;
+}
+</style>

--- a/web/src/components/windows/index.js
+++ b/web/src/components/windows/index.js
@@ -8,3 +8,4 @@ export { default as LogWindow } from "./LogWindow.vue";
 export { default as FilesWindow } from "./FilesWindow.vue";
 export { default as UrlListWindow } from "./UrlListWindow.vue";
 export { default as ImageCompareWindow } from "./ImageCompareWindow.vue";
+export { default as TerminalWindow } from "./TerminalWindow.vue";


### PR DESCRIPTION
When developing with a remote plugin engine, it is often need to interact with the remote machine through a terminal. This PR brings a browser based terminal running in the plugin engine and can be interacted with a web interface. This is especially useful when developing on clusters such as pods running in a Kubernetes cluster.

<img width="1352" alt="Screen Shot 2019-05-18 at 2 27 05 PM" src="https://user-images.githubusercontent.com/478667/57969598-072e7680-7979-11e9-9135-b0e5ed266c10.png">

The terminal window can be opened from the engine panel located in the upper-right corner.

Notice that, this can only work if the plugin engine version is >= 0.8.0 