### PR TITLE
Add ResizeObserver for windows

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.62",
+  "version": "0.9.71",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13469,6 +13469,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
       "dev": true
     },
     "resolve": {

--- a/web/package.json
+++ b/web/package.json
@@ -64,6 +64,7 @@
     "postcss-url": "^7.2.1",
     "prettier": "1.17.0",
     "raw-loader": "^1.0.0",
+    "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^2.6.2",
     "uglify-es": "github:mishoo/UglifyJS2#harmony",
     "uglify-js": "^2.8.29",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.71",
+  "version": "0.9.72",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -199,6 +199,10 @@ ul li {
   margin-top: 0rem !important;
 }
 
+.joy-run-button .md-ripple {
+  justify-content: flex-start !important;
+}
+
 /* for code editor */
 canvas.decorationsOverviewRuler {
   background-color: white;

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -202,4 +202,9 @@ ol li,
 ul li {
   margin-top: 0rem !important;
 }
+
+/* for code editor */
+canvas.decorationsOverviewRuler {
+  background-color: white;
+}
 </style>

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -104,10 +104,6 @@ body {
   justify-content: flex-start !important;
 }
 
-.joy-run-button .md-ripple {
-  justify-content: flex-start !important;
-}
-
 .md-menu-content {
   z-index: 9998;
 }

--- a/web/src/components/FileDialog.vue
+++ b/web/src/components/FileDialog.vue
@@ -92,7 +92,7 @@
           resolve(file_tree_selection);
         "
         >OK
-        <md-tooltip v-if="file_tree_selection"
+        <md-tooltip class="md-small-hide" v-if="file_tree_selection"
           >Selected: {{ file_tree_selection }}</md-tooltip
         >
       </md-button>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -11,8 +11,8 @@
         </md-button>
         <md-button
           @click="$router.push('/')"
-          v-if="!menuVisible"
-          class="md-small-hide site-title-small"
+          v-if="!menuVisible && screenWidth > 400"
+          class="site-title-small"
         >
           <img
             class="site-title-small"
@@ -21,7 +21,7 @@
           />
           <md-tooltip>ImJoy home</md-tooltip>
         </md-button>
-        <md-button v-if="workspace_dropping">
+        <md-button v-if="workspace_dropping && screenWidth > 400">
           Drop files to the workspace.
         </md-button>
         <span

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -593,36 +593,43 @@
                     : plugin.name
                 }}
               </md-button>
-
-              <md-button
-                v-if="plugin._log_history && plugin._log_history.length > 0"
-                class="md-icon-button md-xsmall-hide"
-                @click="showLog(plugin)"
-              >
-                <md-icon v-if="plugin._log_history._error" class="red"
-                  >error</md-icon
+              <div class="floating-right-buttons">
+                <md-button
+                  v-if="plugin._log_history && plugin._log_history.length > 0"
+                  class="md-icon-button md-xsmall-hide"
+                  @click="showLog(plugin)"
                 >
-                <md-icon v-else>info</md-icon>
-                <md-tooltip
-                  v-if="plugin._log_history._error || plugin._log_history._info"
-                  >{{
-                    plugin._log_history._error || plugin._log_history._info
-                  }}</md-tooltip
+                  <md-icon v-if="plugin._log_history._error" class="red"
+                    >error</md-icon
+                  >
+                  <md-icon v-else>info</md-icon>
+                  <md-tooltip
+                    v-if="
+                      plugin._log_history._error || plugin._log_history._info
+                    "
+                    >{{
+                      plugin._log_history._error || plugin._log_history._info
+                    }}</md-tooltip
+                  >
+                </md-button>
+                <md-button
+                  v-else
+                  class="md-icon-button md-xsmall-hide"
+                  disabled
                 >
-              </md-button>
-              <md-button v-else class="md-icon-button md-xsmall-hide" disabled>
-              </md-button>
+                </md-button>
 
-              <md-button
-                class="md-icon-button"
-                @click="
-                  plugin.panel_expanded = !plugin.panel_expanded;
-                  $forceUpdate();
-                "
-              >
-                <md-icon v-if="!plugin.panel_expanded">expand_more</md-icon>
-                <md-icon v-else>expand_less</md-icon>
-              </md-button>
+                <md-button
+                  class="md-icon-button"
+                  @click="
+                    plugin.panel_expanded = !plugin.panel_expanded;
+                    $forceUpdate();
+                  "
+                >
+                  <md-icon v-if="!plugin.panel_expanded">expand_more</md-icon>
+                  <md-icon v-else>expand_less</md-icon>
+                </md-button>
+              </div>
               <md-progress-bar
                 md-mode="determinate"
                 v-if="
@@ -651,15 +658,14 @@
                 >
                   {{ op.name }}
                 </md-button>
-
-                <!-- <md-button class="md-icon-button" v-show="plugin.panel_expanded &&  op.name != plugin.name" @click="op.panel_expanded=!op.panel_expanded; $forceUpdate()"> -->
-                <!-- <md-icon v-if="!op.panel_expanded">expand_more</md-icon>
-                <md-icon v-else>expand_less</md-icon> -->
-                <!-- </md-button> -->
-
-                <joy :config="op" :show="plugin.panel_expanded || false"></joy>
-                <md-divider></md-divider>
               </div>
+              <!-- <md-button class="md-icon-button" v-show="plugin.panel_expanded &&  op.name != plugin.name" @click="op.panel_expanded=!op.panel_expanded; $forceUpdate()"> -->
+              <!-- <md-icon v-if="!op.panel_expanded">expand_more</md-icon>
+                <md-icon v-else>expand_less</md-icon> -->
+              <!-- </md-button> -->
+
+              <joy :config="op" :show="plugin.panel_expanded || false"></joy>
+              <md-divider></md-divider>
             </div>
             <md-divider></md-divider>
             <div>
@@ -741,9 +747,11 @@
                       : plugin.name
                   }}
                 </md-button>
-                <md-button class="md-icon-button" :disabled="true">
-                  <md-icon>visibility_off</md-icon>
-                </md-button>
+                <div class="floating-right-buttons">
+                  <md-button class="md-icon-button" :disabled="true">
+                    <md-icon>visibility_off</md-icon>
+                  </md-button>
+                </div>
                 <md-divider></md-divider>
               </div>
             </div>
@@ -3420,6 +3428,15 @@ button.md-speed-dial-target {
 #plugin-menu > .md-card-content {
   max-height: calc(100vh - 95px - 86px);
   overflow: auto;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+
+@media screen and (max-width: 700px) {
+  #plugin-menu > .md-card-content {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }
 
 #plugin-menu > .md-card-header {
@@ -3545,5 +3562,11 @@ button.md-speed-dial-target {
   bottom: 0;
   left: 0;
   right: 0;
+}
+
+.floating-right-buttons {
+  display: inline-block;
+  margin-left: auto;
+  margin-right: 0;
 }
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -123,7 +123,7 @@
             class="md-icon-button"
           >
             <md-icon>{{ "filter_" + (i + 1) }}</md-icon>
-            <md-tooltip>{{
+            <md-tooltip class="md-xsmall-hide">{{
               w.name.slice(0, 30) + "(#" + w.index + ")"
             }}</md-tooltip>
           </md-button>
@@ -468,7 +468,7 @@
                     plugin.config.icon
                   }}</md-icon>
                   <md-icon v-else>extension</md-icon>
-                  <md-tooltip>{{
+                  <md-tooltip v-if="screenWidth > 500">{{
                     plugin.name + ": " + plugin.config.description
                   }}</md-tooltip>
                 </md-button>
@@ -706,7 +706,7 @@
                       plugin.config.icon
                     }}</md-icon>
                     <md-icon v-else>extension</md-icon>
-                    <md-tooltip>{{
+                    <md-tooltip v-if="screenWidth > 500">{{
                       plugin.name + ": " + plugin.config.description
                     }}</md-tooltip>
                   </md-button>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -3534,7 +3534,7 @@ button.md-speed-dial-target {
 
 @media screen and (max-width: 600px) {
   .joy-run-button {
-    width: calc(100% - 105px)!important;
+    width: calc(100% - 105px) !important;
     text-transform: none;
     font-size: 1.2em;
   }
@@ -3542,7 +3542,7 @@ button.md-speed-dial-target {
 
 @media screen and (max-width: 400px) {
   .joy-run-button {
-    width: calc(100% - 70px)!important;
+    width: calc(100% - 70px) !important;
     text-transform: none;
     font-size: 1.2em;
   }

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -748,6 +748,30 @@
                   }}
                 </md-button>
                 <div class="floating-right-buttons">
+                  <md-button
+                    v-if="plugin._log_history && plugin._log_history.length > 0"
+                    class="md-icon-button md-xsmall-hide"
+                    @click="showLog(plugin)"
+                  >
+                    <md-icon v-if="plugin._log_history._error" class="red"
+                      >error</md-icon
+                    >
+                    <md-icon v-else>info</md-icon>
+                    <md-tooltip
+                      v-if="
+                        plugin._log_history._error || plugin._log_history._info
+                      "
+                      >{{
+                        plugin._log_history._error || plugin._log_history._info
+                      }}</md-tooltip
+                    >
+                  </md-button>
+                  <md-button
+                    v-else
+                    class="md-icon-button md-xsmall-hide"
+                    disabled
+                  >
+                  </md-button>
                   <md-button class="md-icon-button" :disabled="true">
                     <md-icon>visibility_off</md-icon>
                   </md-button>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -3180,7 +3180,7 @@ export default {
 
 @media screen and (max-height: 768px) {
   .site-title-small {
-    height: 45px;
+    height: 36px;
   }
 }
 

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -473,6 +473,19 @@
                   }}</md-tooltip>
                 </md-button>
                 <md-menu-content>
+                  <md-menu-item
+                    @click="showLog(plugin)"
+                    v-if="
+                      plugin._log_history &&
+                        plugin._log_history.length > 0 &&
+                        screenWidth <= 400
+                    "
+                  >
+                    <md-icon v-if="plugin._log_history._error" class="red"
+                      >error_outline</md-icon
+                    >
+                    <md-icon v-else>info</md-icon>Log
+                  </md-menu-item>
                   <md-menu-item @click="showDoc(plugin.id)">
                     <md-icon>description</md-icon>Docs
                   </md-menu-item>
@@ -595,12 +608,16 @@
               </md-button>
               <div class="floating-right-buttons">
                 <md-button
-                  v-if="plugin._log_history && plugin._log_history.length > 0"
-                  class="md-icon-button md-xsmall-hide"
+                  v-if="
+                    plugin._log_history &&
+                      plugin._log_history.length > 0 &&
+                      screenWidth > 400
+                  "
+                  class="md-icon-button"
                   @click="showLog(plugin)"
                 >
                   <md-icon v-if="plugin._log_history._error" class="red"
-                    >error</md-icon
+                    >error_outline</md-icon
                   >
                   <md-icon v-else>info</md-icon>
                   <md-tooltip
@@ -694,6 +711,19 @@
                     }}</md-tooltip>
                   </md-button>
                   <md-menu-content>
+                    <md-menu-item
+                      @click="showLog(plugin)"
+                      v-if="
+                        plugin._log_history &&
+                          plugin._log_history.length > 0 &&
+                          screenWidth <= 400
+                      "
+                    >
+                      <md-icon v-if="plugin._log_history._error" class="red"
+                        >error_outline</md-icon
+                      >
+                      <md-icon v-else>info</md-icon>Log
+                    </md-menu-item>
                     <md-menu-item @click="showDoc(plugin.id)">
                       <md-icon>description</md-icon>Docs
                     </md-menu-item>
@@ -749,12 +779,16 @@
                 </md-button>
                 <div class="floating-right-buttons">
                   <md-button
-                    v-if="plugin._log_history && plugin._log_history.length > 0"
+                    v-if="
+                      plugin._log_history &&
+                        plugin._log_history.length > 0 &&
+                        screenWidth > 400
+                    "
                     class="md-icon-button md-xsmall-hide"
                     @click="showLog(plugin)"
                   >
                     <md-icon v-if="plugin._log_history._error" class="red"
-                      >error</md-icon
+                      >error_outline</md-icon
                     >
                     <md-icon v-else>info</md-icon>
                     <md-tooltip
@@ -3486,6 +3520,32 @@ button.md-speed-dial-target {
   text-align: center;
   margin-top: 10px;
   margin: 5px;
+}
+
+.joy-run-button {
+  width: calc(100% - 120px);
+  text-transform: none;
+  font-size: 1.2em;
+}
+
+.joy-run-button .md-ripple {
+  justify-content: flex-start !important;
+}
+
+@media screen and (max-width: 600px) {
+  .joy-run-button {
+    width: calc(100% - 105px)!important;
+    text-transform: none;
+    font-size: 1.2em;
+  }
+}
+
+@media screen and (max-width: 400px) {
+  .joy-run-button {
+    width: calc(100% - 70px)!important;
+    text-transform: none;
+    font-size: 1.2em;
+  }
 }
 
 @media screen and (max-width: 600px) {

--- a/web/src/components/Joy.vue
+++ b/web/src/components/Joy.vue
@@ -113,11 +113,6 @@ export default {
   font-size: 1.2em;
   font-weight: 100;
 }
-.joy-run-button {
-  width: 60%;
-  text-transform: none;
-  font-size: 1.2em;
-}
 
 @media screen and (max-height: 600px) {
   .joy-run-button {

--- a/web/src/components/Window.vue
+++ b/web/src/components/Window.vue
@@ -100,6 +100,7 @@
 </template>
 
 <script>
+import ResizeObserver from "resize-observer-polyfill";
 import * as windowComponents from "./windows";
 
 const components = {};
@@ -142,6 +143,7 @@ export default {
   },
   mounted() {
     if (this.w) {
+      this.w.$el = this.$el;
       this.w.onRefresh(() => {
         this.refresh();
       });
@@ -152,6 +154,10 @@ export default {
         this.fullScreen(this.w);
       }
     }
+    const ro = new ResizeObserver(entries => {
+      this.w.resize(entries[0].contentRect);
+    });
+    ro.observe(this.$el);
   },
   beforeDestroy() {
     this.w.closed = true;

--- a/web/src/components/windows/Comparify.vue
+++ b/web/src/components/windows/Comparify.vue
@@ -68,7 +68,6 @@
 </template>
 
 <script>
-import ResizeObserver from "resize-observer-polyfill";
 export default {
   name: "comparify",
   props: {
@@ -90,10 +89,6 @@ export default {
     this.$nextTick(() => {
       this.handleResize();
     });
-    const ro = new ResizeObserver(() => {
-      this.handleResize();
-    });
-    ro.observe(this.$el);
   },
   methods: {
     handleInput(e) {

--- a/web/src/components/windows/Comparify.vue
+++ b/web/src/components/windows/Comparify.vue
@@ -68,6 +68,7 @@
 </template>
 
 <script>
+import ResizeObserver from "resize-observer-polyfill";
 export default {
   name: "comparify",
   props: {
@@ -89,6 +90,10 @@ export default {
     this.$nextTick(() => {
       this.handleResize();
     });
+    const ro = new ResizeObserver(() => {
+      this.handleResize();
+    });
+    ro.observe(this.$el);
   },
   methods: {
     handleInput(e) {
@@ -99,7 +104,6 @@ export default {
       const w = this.getContainerWidth();
       if (w === this.width) return;
       this.width = w;
-      console.log(this.width);
     },
     getContainerWidth() {
       return window.getComputedStyle(this.$el, null).getPropertyValue("width");

--- a/web/src/components/windows/Comparify.vue
+++ b/web/src/components/windows/Comparify.vue
@@ -111,11 +111,11 @@ export default {
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
 :root {
-  --handle-width: 50px;
-  --handle-height: 50px;
-  --handle-chevron-size: 30px;
+  --handle-width: 42px;
+  --handle-height: 42px;
+  --handle-chevron-size: 20px;
 
-  --handle-line-width: 5px;
+  --handle-line-width: 3px;
   --handle-line-height: 100%;
 
   --z-index-handle: 5;
@@ -178,6 +178,7 @@ export default {
   border-radius: 50%;
   width: var(--handle-width);
   height: var(--handle-height);
+  opacity: 0.75;
 }
 
 .handle-line {
@@ -190,6 +191,7 @@ export default {
   z-index: var(--z-index-handle-line);
   pointer-events: none;
   user-select: none;
+  opacity: 0.8;
 }
 
 .compare__range {
@@ -201,7 +203,7 @@ export default {
   top: calc(50%);
   z-index: var(--z-index-range-input);
   -webkit-appearance: none;
-  height: var(--handle-height);
+  height: 100%;
   /* debugging purposes only */
   background: rgba(0, 0, 0, 0.4);
   opacity: 0;

--- a/web/src/windowManager.js
+++ b/web/src/windowManager.js
@@ -100,8 +100,9 @@ export class WindowManager {
     w.onResize = handler => {
       w._resize_callbacks.push(handler);
     };
-    w.resize = async () => {
-      await Promise.all(w._resize_callbacks.map(item => item()));
+    w.resize = async contentRect => {
+      contentRect = contentRect || (w.$el && w.$el.getBoundingClientRect());
+      await Promise.all(w._resize_callbacks.map(item => item(contentRect)));
     };
 
     w._close_callbacks = [];


### PR DESCRIPTION
 * use ResizeObserver (https://github.com/que-etc/resize-observer-polyfill) to detect window size changes which makes the windows much more reactive
 * improve image compare window
 * improve floating buttons in the plugin menu
 * hide tooltips on small screens