### PR TITLE
Load source code file from the plugin engine

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.74",
+  "version": "0.9.75",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2903,7 +2903,7 @@ export default {
           .get({
             url: config.url,
             method: config.method || "GET",
-            responseType: config.method || "blob",
+            responseType: config.responseType || "blob",
             onDownloadProgress: progressEvent => {
               totalLength =
                 totalLength || progressEvent.lengthComputable

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2145,7 +2145,7 @@ export default {
         reader.readAsText(file);
       };
 
-      const engine_loader = engine_file_obj => {
+      const engine_code_loader = engine_file_obj => {
         const w = {
           name: "New Plugin",
           type: "imjoy/plugin-editor",
@@ -2164,6 +2164,16 @@ export default {
           },
         };
         this.createWindow(w);
+      };
+
+      const engine_image_loader = engine_image_file => {
+        const tmp = engine_image_file.url.split("/");
+        const file_name = tmp[tmp.length - 1];
+        this.createWindow({
+          name: file_name,
+          type: "imjoy/image",
+          data: { src: engine_image_file.url },
+        });
       };
 
       return [
@@ -2188,7 +2198,7 @@ export default {
             },
             required: ["url", "path", "engine"],
           }),
-          loader: engine_loader,
+          loader: engine_code_loader,
         },
         {
           loader_key: "Image",
@@ -2203,6 +2213,21 @@ export default {
             required: ["type", "size"],
           }),
           loader: image_loader,
+        },
+        {
+          loader_key: "Image",
+          schema: ajv.compile({
+            properties: {
+              url: {
+                type: "string",
+                pattern: "(.*\\.jpg|\\.jpeg|\\.png|\\.gif)$",
+              },
+              path: { type: "string" },
+              engine: { type: "string" },
+            },
+            required: ["url", "path", "engine"],
+          }),
+          loader: engine_image_loader,
         },
       ];
     },

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2144,6 +2144,28 @@ export default {
         };
         reader.readAsText(file);
       };
+
+      const engine_loader = engine_file_obj => {
+        const w = {
+          name: "New Plugin",
+          type: "imjoy/plugin-editor",
+          config: {},
+          plugin_manager: this.pm,
+          engine_manager: this.em,
+          w: 30,
+          h: 20,
+          standalone: this.screenWidth < 1200,
+          plugin: {},
+          data: {
+            name: "new plugin",
+            id: "plugin_" + randId(),
+            code: "",
+            engine_file_obj: engine_file_obj,
+          },
+        };
+        this.createWindow(w);
+      };
+
       return [
         {
           loader_key: "Code Editor",
@@ -2155,6 +2177,18 @@ export default {
             required: ["name", "size"],
           }),
           loader: code_loader,
+        },
+        {
+          loader_key: "Code Editor",
+          schema: ajv.compile({
+            properties: {
+              url: { type: "string", pattern: ".*\\.imjoy.html$" },
+              path: { type: "string" },
+              engine: { type: "string" },
+            },
+            required: ["url", "path", "engine"],
+          }),
+          loader: engine_loader,
         },
         {
           loader_key: "Image",
@@ -2382,24 +2416,39 @@ export default {
           if (!selection) {
             return;
           }
-          if (!Array.isArray(selection)) {
-            selection = [selection];
-          }
-          const urls = [];
-          for (let u of selection) {
-            if (u.url) {
-              urls.push({ href: u.url, path: u.path, engine: u.engine });
-            } else {
-              urls.push({ href: u });
+
+          const loaders = this.wm.getDataLoaders(selection);
+          const keys = Object.keys(loaders);
+          if (keys.length > 1) {
+            const w = {
+              name: "Engine Files",
+              type: "imjoy/generic",
+              scroll: true,
+              data: selection,
+            };
+            this.createWindow(w);
+          } else if (keys.length === 1) {
+            this.wm.registered_loaders[loaders[keys[0]]](selection);
+          } else {
+            if (!Array.isArray(selection)) {
+              selection = [selection];
             }
+            const urls = [];
+            for (let u of selection) {
+              if (u.url) {
+                urls.push(u);
+              } else {
+                urls.push({ url: u });
+              }
+            }
+            const w = {
+              name: "Files",
+              type: "imjoy/url_list",
+              scroll: true,
+              data: urls,
+            };
+            this.createWindow(w);
           }
-          const w = {
-            name: "Files",
-            type: "imjoy/url_list",
-            scroll: true,
-            data: urls,
-          };
-          this.createWindow(w);
         })
         .catch(e => {
           throw e;

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -318,31 +318,19 @@ export default {
       };
       reader.readAsText(file);
     },
-    async openEnigneFile() {
+    async openEnigneFile(config) {
       const api = this.window.plugin_manager.imjoy_api;
       try {
-        const retObj = await api.showFileDialog(null, {
-          title: "Load plugin source file",
-          uri_type: "url",
-          mode: "single",
-          type: "file",
-        });
-        const response = await axios.get(retObj.url + "?" + randId());
-        if (response && response.data) {
-          const code = response.data;
-          this.window.plugin_manager.parsePluginCode(code);
-          this.editor.setValue(code);
-          this.code_origin = retObj;
-          this.window.plugin_manager.showMessage(
-            `Successfully loading source code from ${retObj.engine}: ${
-              retObj.path
-            }.`
-          );
-        } else {
-          this.window.plugin_manager.showMessage(
-            "Failed to load plugin source code."
-          );
-        }
+        const retObj =
+          config ||
+          (await api.showFileDialog(null, {
+            title: "Load plugin source file",
+            uri_type: "url",
+            mode: "single",
+            type: "file",
+          }));
+        this.code_origin = retObj;
+        this.load_code_from_origin();
       } catch (e) {
         this.window.plugin_manager.showMessage(
           `Failed to load plugin source code, error: ${e}`
@@ -354,7 +342,8 @@ export default {
         const response = await axios.get(this.code_origin.url + "?" + randId());
         if (response && response.data) {
           const code = response.data;
-          this.window.plugin_manager.parsePluginCode(code);
+          const config = this.window.plugin_manager.parsePluginCode(code);
+          this.window.name = config.name;
           this.editor.setValue(code);
           this.window.plugin_manager.showMessage(
             `Successfully loading source code from ${

--- a/web/src/components/windows/PluginEditorWindow.vue
+++ b/web/src/components/windows/PluginEditorWindow.vue
@@ -1,5 +1,6 @@
 <template>
   <plugin-editor
+    ref="code_editor"
     class="no-drag fill-container"
     :pluginId="w.data.id"
     :window="w"
@@ -25,6 +26,11 @@ export default {
         return null;
       },
     },
+  },
+  mounted() {
+    if (this.w.data.engine_file_obj) {
+      this.$refs.code_editor.openEnigneFile(this.w.data.engine_file_obj);
+    }
   },
   methods: {
     dataSummary(w) {

--- a/web/src/components/windows/UrlListWindow.vue
+++ b/web/src/components/windows/UrlListWindow.vue
@@ -1,7 +1,7 @@
 <template>
   <ul v-if="w.data && w.data.length && w.data.length > 0">
-    <li v-for="u in w.data" :key="u.href || u">
-      <a :href="u.href || u" target="_blank">{{ u.text || u }}</a>
+    <li v-for="u in w.data" :key="u.url || u">
+      <a :href="u.url || u" target="_blank">{{ u.text || u }}</a>
     </li>
   </ul>
   <p v-else>No url.</p>

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1067,6 +1067,7 @@ export class PluginManager {
 
   parsePluginCode(code, overwrite_config) {
     let config = {};
+    overwrite_config = overwrite_config || {};
     const uri = overwrite_config.uri;
     try {
       if (uri && uri.endsWith(".js")) {


### PR DESCRIPTION
This PR is about supporting any native code editors by allowing the code editor in ImJoy to load local/remote files directly:

 * load plugin file from local file system
 * load plugin file from the plugin engine (local/remote), and also quickly fetch the new version if the file has been changed.
 * When open a plugin from the plugin engine file dialog, the code editor will open it directly.

This closes #170 