### PR TITLE
Check plugin update automatically

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,8 @@
     "vue-grid-layout": "github:jbaysolutions/vue-grid-layout#9e13ea9",
     "vue-material": "^1.0.0-beta-11",
     "vue-router": "^3.0.1",
-    "xterm": "^3.13.1"
+    "xterm": "^3.13.1",
+    "spark-md5": "^3.0.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.1.1",

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -207,4 +207,8 @@ ul li {
 canvas.decorationsOverviewRuler {
   background-color: white;
 }
+
+.hide-badge > .md-badge {
+  display: none !important;
+}
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -452,144 +452,144 @@
 
             <div v-for="plugin in sortedRunnablePlugins()" :key="plugin.name">
               <md-divider></md-divider>
-              <md-menu md-size="medium">
-                <md-badge
-                  v-if="plugin.update_available"
-                  class="md-square md-primary update-badge"
-                  md-dense
-                  md-content="NEW"
-                >
-                </md-badge>
-                <md-button
-                  class="md-icon-button"
-                  :class="plugin.running ? 'md-accent' : ''"
-                  md-menu-trigger
-                >
-                  <md-progress-spinner
-                    v-if="plugin.initializing"
-                    class="md-accent"
-                    :md-diameter="20"
-                    md-mode="indeterminate"
-                  ></md-progress-spinner>
-                  <md-icon v-else-if="plugin.config.icon">{{
-                    plugin.config.icon
-                  }}</md-icon>
-                  <md-icon v-else>extension</md-icon>
-                  <md-tooltip v-if="screenWidth > 500">{{
-                    plugin.name + ": " + plugin.config.description
-                  }}</md-tooltip>
-                </md-button>
+              <md-badge
+                :class="plugin.update_available ? '' : 'hide-badge'"
+                class="md-square md-primary"
+                md-dense
+                md-content="NEW"
+              >
+                <md-menu md-size="medium">
+                  <md-button
+                    class="md-icon-button"
+                    :class="plugin.running ? 'md-accent' : ''"
+                    md-menu-trigger
+                  >
+                    <md-progress-spinner
+                      v-if="plugin.initializing"
+                      class="md-accent"
+                      :md-diameter="20"
+                      md-mode="indeterminate"
+                    ></md-progress-spinner>
+                    <md-icon v-else-if="plugin.config.icon">{{
+                      plugin.config.icon
+                    }}</md-icon>
+                    <md-icon v-else>extension</md-icon>
 
-                <md-menu-content>
-                  <md-menu-item
-                    v-if="plugin.config.origin"
-                    @click="updatePlugin(plugin.id)"
-                  >
-                    <md-icon
-                      :class="plugin.update_available ? 'md-primary' : ''"
-                      >cloud_download</md-icon
-                    >Update
-                  </md-menu-item>
-                  <md-menu-item
-                    @click="showLog(plugin)"
-                    v-if="
-                      plugin._log_history &&
-                        plugin._log_history.length > 0 &&
-                        screenWidth <= 400
-                    "
-                  >
-                    <md-icon v-if="plugin._log_history._error" class="red"
-                      >error_outline</md-icon
-                    >
-                    <md-icon v-else>info</md-icon>Log
-                  </md-menu-item>
-                  <md-menu-item @click="showDoc(plugin.id)">
-                    <md-icon>description</md-icon>Docs
-                  </md-menu-item>
-                  <md-menu-item
-                    v-if="plugin.config.origin"
-                    @click="sharePlugin(plugin.id)"
-                  >
-                    <md-icon>share</md-icon>Share
-                  </md-menu-item>
-                  <md-menu-item v-else @click="downloadPlugin(plugin.id)">
-                    <md-icon>cloud_download</md-icon>Export
-                  </md-menu-item>
-                  <md-menu-item @click="editPlugin(plugin.id)">
-                    <md-icon>edit</md-icon>Edit
-                  </md-menu-item>
-                  <md-menu-item @click="reloadPlugin(plugin.config)">
-                    <md-icon>autorenew</md-icon>Reload
-                  </md-menu-item>
-                  <md-menu-item @click="unloadPlugin(plugin)">
-                    <md-icon>clear</md-icon>Terminate
-                  </md-menu-item>
-                  <md-menu-item
-                    class="md-accent"
-                    @click="
-                      plugin2_remove = plugin;
-                      showRemoveConfirmation = true;
-                    "
-                  >
-                    <md-icon>delete_forever</md-icon>Remove
-                  </md-menu-item>
-                  <div v-if="plugin.config.type === 'native-python'">
-                    <md-divider></md-divider>
-                    <md-menu-item @click="switchEngine(plugin, 'auto')">
-                      <md-icon v-if="plugin.config.engine_mode === 'auto'"
-                        >check_box</md-icon
-                      >
-                      <md-icon v-else>check_box_outline_blank</md-icon>
+                    <md-tooltip v-if="screenWidth > 500">{{
+                      plugin.name + ": " + plugin.config.description
+                    }}</md-tooltip>
+                  </md-button>
 
-                      <span
-                        :class="
-                          plugin.config.engine_mode === 'auto' ? 'bold' : ''
-                        "
-                        >Auto</span
-                      >
-                    </md-menu-item>
+                  <md-menu-content>
                     <md-menu-item
-                      v-for="engine in em.engines"
-                      :key="engine.id"
-                      @click="switchEngine(plugin, engine)"
+                      v-if="plugin.config.origin"
+                      @click="updatePlugin(plugin.id)"
                     >
                       <md-icon
-                        v-if="
-                          plugin.config.engine_mode === engine.id ||
-                            (plugin.config.engine &&
-                              plugin.config.engine.id === engine.id)
-                        "
-                        >radio_button_checked</md-icon
-                      >
-                      <md-icon v-else>radio_button_unchecked</md-icon>
-                      <span
-                        :class="
-                          plugin.config.engine &&
-                          plugin.config.engine.id === engine.id
-                            ? 'bold'
-                            : ''
-                        "
-                        >{{ engine.name }}</span
-                      >
+                        :class="plugin.update_available ? 'md-primary' : ''"
+                        >cloud_download</md-icon
+                      >Update
                     </md-menu-item>
-                    <md-divider></md-divider>
                     <md-menu-item
-                      v-for="tag in plugin.config.tags"
-                      :key="tag"
-                      @click="switchTag(plugin, tag)"
+                      @click="showLog(plugin)"
+                      v-if="
+                        plugin._log_history &&
+                          plugin._log_history.length > 0 &&
+                          screenWidth <= 400
+                      "
                     >
-                      <md-icon v-if="plugin.config.tag === tag"
-                        >radio_button_checked</md-icon
+                      <md-icon v-if="plugin._log_history._error" class="red"
+                        >error_outline</md-icon
                       >
-                      <md-icon v-else>radio_button_unchecked</md-icon>
-                      <span :class="plugin.config.tag === tag ? 'bold' : ''"
-                        >Tag: {{ tag }}</span
-                      >
+                      <md-icon v-else>info</md-icon>Log
                     </md-menu-item>
-                  </div>
-                </md-menu-content>
-              </md-menu>
+                    <md-menu-item @click="showDoc(plugin.id)">
+                      <md-icon>description</md-icon>Docs
+                    </md-menu-item>
+                    <md-menu-item
+                      v-if="plugin.config.origin"
+                      @click="sharePlugin(plugin.id)"
+                    >
+                      <md-icon>share</md-icon>Share
+                    </md-menu-item>
+                    <md-menu-item v-else @click="downloadPlugin(plugin.id)">
+                      <md-icon>cloud_download</md-icon>Export
+                    </md-menu-item>
+                    <md-menu-item @click="editPlugin(plugin.id)">
+                      <md-icon>edit</md-icon>Edit
+                    </md-menu-item>
+                    <md-menu-item @click="reloadPlugin(plugin.config)">
+                      <md-icon>autorenew</md-icon>Reload
+                    </md-menu-item>
+                    <md-menu-item @click="unloadPlugin(plugin)">
+                      <md-icon>clear</md-icon>Terminate
+                    </md-menu-item>
+                    <md-menu-item
+                      class="md-accent"
+                      @click="
+                        plugin2_remove = plugin;
+                        showRemoveConfirmation = true;
+                      "
+                    >
+                      <md-icon>delete_forever</md-icon>Remove
+                    </md-menu-item>
+                    <div v-if="plugin.config.type === 'native-python'">
+                      <md-divider></md-divider>
+                      <md-menu-item @click="switchEngine(plugin, 'auto')">
+                        <md-icon v-if="plugin.config.engine_mode === 'auto'"
+                          >check_box</md-icon
+                        >
+                        <md-icon v-else>check_box_outline_blank</md-icon>
 
+                        <span
+                          :class="
+                            plugin.config.engine_mode === 'auto' ? 'bold' : ''
+                          "
+                          >Auto</span
+                        >
+                      </md-menu-item>
+                      <md-menu-item
+                        v-for="engine in em.engines"
+                        :key="engine.id"
+                        @click="switchEngine(plugin, engine)"
+                      >
+                        <md-icon
+                          v-if="
+                            plugin.config.engine_mode === engine.id ||
+                              (plugin.config.engine &&
+                                plugin.config.engine.id === engine.id)
+                          "
+                          >radio_button_checked</md-icon
+                        >
+                        <md-icon v-else>radio_button_unchecked</md-icon>
+                        <span
+                          :class="
+                            plugin.config.engine &&
+                            plugin.config.engine.id === engine.id
+                              ? 'bold'
+                              : ''
+                          "
+                          >{{ engine.name }}</span
+                        >
+                      </md-menu-item>
+                      <md-divider></md-divider>
+                      <md-menu-item
+                        v-for="tag in plugin.config.tags"
+                        :key="tag"
+                        @click="switchTag(plugin, tag)"
+                      >
+                        <md-icon v-if="plugin.config.tag === tag"
+                          >radio_button_checked</md-icon
+                        >
+                        <md-icon v-else>radio_button_unchecked</md-icon>
+                        <span :class="plugin.config.tag === tag ? 'bold' : ''"
+                          >Tag: {{ tag }}</span
+                        >
+                      </md-menu-item>
+                    </div>
+                  </md-menu-content>
+                </md-menu>
+              </md-badge>
               <md-button
                 class="joy-run-button"
                 :class="
@@ -702,83 +702,82 @@
                 v-for="plugin in sortedNonRunnablePlugins()"
                 :key="plugin.name"
               >
-                <md-menu md-size="medium">
-                  <md-badge
-                    v-if="plugin.update_available"
-                    class="md-square md-primary update-badge"
-                    md-dense
-                    md-content="NEW"
-                  >
-                  </md-badge>
-                  <md-button
-                    class="md-icon-button"
-                    :class="plugin.running ? 'md-accent' : ''"
-                    md-menu-trigger
-                  >
-                    <md-progress-spinner
-                      v-if="plugin.initializing"
-                      class="md-accent"
-                      :md-diameter="20"
-                      md-mode="indeterminate"
-                    ></md-progress-spinner>
-                    <md-icon v-else-if="plugin.config.icon">{{
-                      plugin.config.icon
-                    }}</md-icon>
-                    <md-icon v-else>extension</md-icon>
-                    <md-tooltip v-if="screenWidth > 500">{{
-                      plugin.name + ": " + plugin.config.description
-                    }}</md-tooltip>
-                  </md-button>
-                  <md-menu-content>
-                    <md-menu-item
-                      v-if="plugin.config.origin"
-                      @click="updatePlugin(plugin.id)"
+                <md-badge
+                  :class="plugin.update_available ? '' : 'hide-badge'"
+                  class="md-square md-primary"
+                  md-dense
+                  md-content="NEW"
+                >
+                  <md-menu md-size="medium">
+                    <md-button
+                      class="md-icon-button"
+                      :class="plugin.running ? 'md-accent' : ''"
+                      md-menu-trigger
                     >
-                      <md-icon
-                        :class="plugin.update_available ? 'md-primary' : ''"
-                        >cloud_download</md-icon
-                      >Update
-                    </md-menu-item>
-                    <md-menu-item
-                      @click="showLog(plugin)"
-                      v-if="
-                        plugin._log_history &&
-                          plugin._log_history.length > 0 &&
-                          screenWidth <= 400
-                      "
-                    >
-                      <md-icon v-if="plugin._log_history._error" class="red"
-                        >error_outline</md-icon
+                      <md-progress-spinner
+                        v-if="plugin.initializing"
+                        class="md-accent"
+                        :md-diameter="20"
+                        md-mode="indeterminate"
+                      ></md-progress-spinner>
+                      <md-icon v-else-if="plugin.config.icon">{{
+                        plugin.config.icon
+                      }}</md-icon>
+                      <md-icon v-else>extension</md-icon>
+                      <md-tooltip v-if="screenWidth > 500">{{
+                        plugin.name + ": " + plugin.config.description
+                      }}</md-tooltip>
+                    </md-button>
+                    <md-menu-content>
+                      <md-menu-item
+                        v-if="plugin.config.origin"
+                        @click="updatePlugin(plugin.id)"
                       >
-                      <md-icon v-else>info</md-icon>Log
-                    </md-menu-item>
-                    <md-menu-item @click="showDoc(plugin.id)">
-                      <md-icon>description</md-icon>Docs
-                    </md-menu-item>
-                    <md-menu-item @click="sharePlugin(plugin.id)">
-                      <md-icon>share</md-icon>Share
-                    </md-menu-item>
-                    <md-menu-item @click="editPlugin(plugin.id)">
-                      <md-icon>edit</md-icon>Edit
-                    </md-menu-item>
-                    <md-menu-item @click="reloadPlugin(plugin.config)">
-                      <md-icon>autorenew</md-icon>Reload
-                    </md-menu-item>
-                    <md-menu-item @click="unloadPlugin(plugin)">
-                      <md-icon>clear</md-icon>Terminate
-                    </md-menu-item>
-                    <md-menu-item
-                      class="md-accent"
-                      @click="
-                        plugin2_remove = plugin;
-                        showRemoveConfirmation = true;
-                      "
-                    >
-                      <md-icon>delete_forever</md-icon>Remove
-                    </md-menu-item>
-                  </md-menu-content>
-                </md-menu>
-
+                        <md-icon
+                          :class="plugin.update_available ? 'md-primary' : ''"
+                          >cloud_download</md-icon
+                        >Update
+                      </md-menu-item>
+                      <md-menu-item
+                        @click="showLog(plugin)"
+                        v-if="
+                          plugin._log_history &&
+                            plugin._log_history.length > 0 &&
+                            screenWidth <= 400
+                        "
+                      >
+                        <md-icon v-if="plugin._log_history._error" class="red"
+                          >error_outline</md-icon
+                        >
+                        <md-icon v-else>info</md-icon>Log
+                      </md-menu-item>
+                      <md-menu-item @click="showDoc(plugin.id)">
+                        <md-icon>description</md-icon>Docs
+                      </md-menu-item>
+                      <md-menu-item @click="sharePlugin(plugin.id)">
+                        <md-icon>share</md-icon>Share
+                      </md-menu-item>
+                      <md-menu-item @click="editPlugin(plugin.id)">
+                        <md-icon>edit</md-icon>Edit
+                      </md-menu-item>
+                      <md-menu-item @click="reloadPlugin(plugin.config)">
+                        <md-icon>autorenew</md-icon>Reload
+                      </md-menu-item>
+                      <md-menu-item @click="unloadPlugin(plugin)">
+                        <md-icon>clear</md-icon>Terminate
+                      </md-menu-item>
+                      <md-menu-item
+                        class="md-accent"
+                        @click="
+                          plugin2_remove = plugin;
+                          showRemoveConfirmation = true;
+                        "
+                      >
+                        <md-icon>delete_forever</md-icon>Remove
+                      </md-menu-item>
+                    </md-menu-content>
+                  </md-menu>
+                </md-badge>
                 <md-button
                   class="joy-run-button"
                   :class="
@@ -3766,9 +3765,7 @@ button.md-speed-dial-target {
   margin-right: 0;
 }
 
-.update-badge {
-  position: absolute;
-  left: 10px;
-  width: 22px !important;
+.hide-badge > .md-badge {
+  display: none;
 }
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1402,6 +1402,7 @@ import {
   compareVersions,
   HtmlWhitelistedSanitizer,
   escapeHTML,
+  isTouchDevice,
 } from "../utils.js";
 
 import { PluginManager } from "../pluginManager.js";
@@ -1779,7 +1780,7 @@ export default {
     });
 
     this.updateSize({ width: window.innerWidth });
-    if (this.screenWidth > 800) {
+    if (this.screenWidth > 800 && !isTouchDevice()) {
       this.wm.window_mode = "grid";
     } else {
       this.wm.window_mode = "single";
@@ -2254,7 +2255,7 @@ export default {
     },
     updateSize(e) {
       this.screenWidth = e.width;
-      if (this.screenWidth > 800) {
+      if (this.screenWidth > 800 && !isTouchDevice()) {
         if (this.wm.windows.length === 0) this.wm.window_mode = "grid";
         this.max_window_buttons = 9;
       } else {
@@ -3763,9 +3764,5 @@ button.md-speed-dial-target {
   display: inline-block;
   margin-left: auto;
   margin-right: 0;
-}
-
-.hide-badge > .md-badge {
-  display: none;
 }
 </style>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -223,7 +223,7 @@
                 >
                 <md-icon v-else>error_outline</md-icon>
                 <div
-                  @click.stop="checkUpdate"
+                  @click.stop="checkImJoyUpdate"
                   style="width: 100%;cursor: pointer;"
                 >
                   <div
@@ -2038,10 +2038,10 @@ export default {
       }
       this.$forceUpdate();
       this.$nextTick(() => {
-        this.checkUpdate();
+        this.checkImJoyUpdate();
         //check for update every 20 minutes
         window.setInterval(() => {
-          this.checkUpdate(true);
+          this.checkImJoyUpdate(true);
         }, 1200000);
       });
     },
@@ -2076,7 +2076,7 @@ export default {
     createWindow(w) {
       return this.pm.createWindow(null, w);
     },
-    async checkUpdate(quiet) {
+    async checkImJoyUpdate(quiet) {
       this.checking = true;
       try {
         const response = await axios.get(

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1402,7 +1402,6 @@ import {
   compareVersions,
   HtmlWhitelistedSanitizer,
   escapeHTML,
-  isTouchDevice,
 } from "../utils.js";
 
 import { PluginManager } from "../pluginManager.js";
@@ -1780,7 +1779,7 @@ export default {
     });
 
     this.updateSize({ width: window.innerWidth });
-    if (this.screenWidth > 800 && !isTouchDevice()) {
+    if (this.screenWidth > 800) {
       this.wm.window_mode = "grid";
     } else {
       this.wm.window_mode = "single";
@@ -2255,7 +2254,7 @@ export default {
     },
     updateSize(e) {
       this.screenWidth = e.width;
-      if (this.screenWidth > 800 && !isTouchDevice()) {
+      if (this.screenWidth > 800) {
         if (this.wm.windows.length === 0) this.wm.window_mode = "grid";
         this.max_window_buttons = 9;
       } else {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2506,8 +2506,11 @@ export default {
       const plugin = this.pm.plugins[pid];
       const pconfig = plugin.config;
       if (pconfig.origin) {
+        this.showMessage("Fetching plugin file...");
         this.getPlugin4Install(pconfig.origin)
           .then(() => {
+            //clear message
+            this.showStatus(null, " ");
             this.show_plugin_templates = false;
             this.showAddPluginDialog = true;
             this.init_plugin_search = null;
@@ -2515,7 +2518,7 @@ export default {
             this.show_plugin_url = false;
           })
           .catch(e => {
-            this.showAlert(null, `Failed to fetch plugin source code (${e})`);
+            this.showMessage(`Failed to fetch plugin source code (${e}).`);
             console.error(e);
           });
       } else {

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -227,6 +227,7 @@ export default {
             pluginId: this.pluginId,
             code: this.codeValue,
             tag: this.window.plugin && this.window.plugin.tag,
+            origin: this.window.plugin && this.window.plugin.origin,
           })
           .then(config => {
             // this.window.data._id = config._id

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -24,12 +24,7 @@
         </md-button>
         <md-button
           @click="remove()"
-          v-if="
-            window &&
-              window.plugin &&
-              window.plugin.config &&
-              window.plugin.config._id
-          "
+          v-if="window && window.plugin && window.plugin._id"
           class="md-icon-button"
         >
           <md-icon>delete</md-icon>
@@ -71,14 +66,13 @@
               window &&
               window.plugin &&
               window.plugin.type === 'native-python' &&
-              window.plugin.config &&
               window.engine_manager
           "
         >
           <md-select
             id="engine_mode"
             @md-selected="reload()"
-            v-model="window.plugin.config.engine_mode"
+            v-model="window.plugin.engine_mode"
             name="tag"
           >
             <md-option value="auto">auto</md-option>
@@ -307,17 +301,17 @@ export default {
     },
     reload() {
       assert(this.window.plugin_manager);
-
+      this.$forceUpdate();
       return new Promise((resolve, reject) => {
-        if (!this.editor || !this.saved) {
-          reject("editor is not available or never saved");
+        if (!this.editor) {
+          reject("editor is not available.");
           return;
         }
         this.codeValue = this.editor.getValue();
         if (this.codeValue) {
           this.$emit("input", this.codeValue);
-          if (this.window.plugin && this.window.plugin.config) {
-            this.window.plugin.config.code = this.codeValue;
+          if (this.window.plugin) {
+            this.window.plugin.code = this.codeValue;
           }
           let newTag = this.window.plugin.tag;
           const config = this.window.data && this.window.data.config;
@@ -329,9 +323,7 @@ export default {
             }
           }
           const engine_mode =
-            this.window.plugin &&
-            this.window.plugin.config &&
-            this.window.plugin.config.engine_mode;
+            this.window.plugin && this.window.plugin.engine_mode;
           this.window.plugin_manager
             .reloadPlugin({
               _id: this.window.data._id,
@@ -339,9 +331,10 @@ export default {
               tag: newTag,
               name: this.window.data._name,
               code: this.codeValue,
+              origin: this.window.plugin && this.window.plugin.origin,
             })
             .then(plugin => {
-              this.window.plugin = plugin;
+              this.window.plugin = plugin.config;
               this.$forceUpdate();
               resolve();
             })

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -23,7 +23,7 @@
 
           <md-menu-content>
             <md-menu-item
-              @click="openEnigneFile()"
+              @click="openEngineFile()"
               :disabled="window.engine_manager.engines.length <= 0"
             >
               <md-icon>add_to_queue</md-icon>Open Engine File
@@ -313,11 +313,11 @@ export default {
       };
       reader.readAsText(file);
     },
-    async openEnigneFile(config) {
+    async openEngineFile(fileObj) {
       const api = this.window.plugin_manager.imjoy_api;
       try {
         const retObj =
-          config ||
+          fileObj ||
           (await api.showFileDialog(null, {
             title: "Load plugin source file",
             uri_type: "url",

--- a/web/src/components/Whiteboard.vue
+++ b/web/src/components/Whiteboard.vue
@@ -3,7 +3,7 @@
     class="whiteboard noselect"
     ref="whiteboard"
     @mouseup="show_overlay = false"
-    @click="unselectWindows()"
+    @click="unselectWindows($event)"
   >
     <div
       @mousemove="overlayMousemove"
@@ -295,7 +295,10 @@ export default {
         standalone: w.standalone,
       });
     },
-    unselectWindows() {
+    unselectWindows(e) {
+      if (!e.target.classList.contains("vue-grid-layout")) {
+        return;
+      }
       if (this.active_windows && this.active_windows.length > 0) {
         for (let i = 0; i < this.active_windows.length; i++) {
           this.active_windows[i].selected = false;

--- a/web/src/components/Window.vue
+++ b/web/src/components/Window.vue
@@ -1,80 +1,70 @@
 <template>
-  <md-card v-if="w">
-    <md-card-expand
+  <md-card
+    v-if="w"
+    @click.native="selectWindow(w, $event)"
+    @dblclick.native="w._h && w._w ? normalSize(w) : fullScreen(w)"
+  >
+    <md-card-actions
       v-if="!w.standalone"
-      @click.native.stop="selectWindow(w, $event)"
-      @dblclick.native.stop="w._h && w._w ? normalSize(w) : fullScreen(w)"
-      :class="{ 'drag-handle': withDragHandle }"
+      :class="{
+        'drag-handle': withDragHandle,
+        'window-selected': w.selected,
+        'window-header': !w.selected,
+      }"
+      md-alignment="space-between"
     >
-      <md-card-actions
-        md-alignment="space-between"
-        :class="w.selected ? 'window-selected' : 'window-header'"
-      >
-        <md-card-expand-trigger v-if="w.panel">
-          <md-button class="md-icon-button">
-            <md-icon>keyboard_arrow_down</md-icon>
+      <md-button class="md-icon-button md-accent" @click="close(w)">
+        <md-icon>close</md-icon>
+      </md-button>
+      <div class="window-title noselect">
+        {{ w.name.slice(0, 30) + "(#" + w.index + ")" }}
+      </div>
+      <div>
+        <md-menu md-size="big" md-direction="bottom-end">
+          <md-button class="md-icon-button" md-menu-trigger>
+            <md-icon>more_vert</md-icon>
           </md-button>
-        </md-card-expand-trigger>
-        <md-button class="md-icon-button md-accent" @click="close(w)">
-          <md-icon>close</md-icon>
-        </md-button>
-        <div class="window-title noselect">
-          {{ w.name.slice(0, 30) + "(#" + w.index + ")" }}
-        </div>
-        <div>
-          <md-menu md-size="big" md-direction="bottom-end">
-            <md-button class="md-icon-button" md-menu-trigger>
-              <md-icon>more_vert</md-icon>
-            </md-button>
-            <md-menu-content>
-              <md-menu-item
-                @click.stop="normalSize(w)"
-                v-if="!w.standalone && w.fullscreen"
-              >
-                <span>Normal view</span>
-                <md-icon>fullscreen</md-icon>
-              </md-menu-item>
-              <md-menu-item
-                @click.stop="fullScreen(w)"
-                v-else-if="!w.standalone"
-              >
-                <span>Fullscreen</span>
-                <md-icon>fullscreen</md-icon>
-              </md-menu-item>
-              <md-menu-item @click.stop="detach(w)" v-if="!w.standalone">
-                <span>Detach</span>
-                <md-icon>launch</md-icon>
-              </md-menu-item>
-              <md-menu-item @click.stop="duplicate(w)">
-                <span>Duplicate</span>
-                <md-icon>filter</md-icon>
-              </md-menu-item>
-              <md-menu-item @click="close(w)">
-                <span>Close</span>
-                <md-icon>close</md-icon>
-              </md-menu-item>
-              <md-menu-item @click="printObject(w.type, w.data, w)">
-                <span>Console.log</span>
-                <md-icon>bug_report</md-icon>
-              </md-menu-item>
-              <md-menu-item
-                v-for="(loader, name) in w.loaders"
-                :key="name"
-                @click="loaders && loaders[loader](w.data)"
-              >
-                <span>{{ name }}</span>
-                <md-icon>play_arrow</md-icon>
-              </md-menu-item>
-            </md-menu-content>
-          </md-menu>
-        </div>
-      </md-card-actions>
-      <md-card-expand-content v-if="w.panel">
-        <md-card-content>
-          <joy :config="w.panel"></joy>
-        </md-card-content>
-      </md-card-expand-content>
-    </md-card-expand>
+          <md-menu-content>
+            <md-menu-item
+              @click="normalSize(w)"
+              v-if="!w.standalone && w.fullscreen"
+            >
+              <span>Normal view</span>
+              <md-icon>fullscreen</md-icon>
+            </md-menu-item>
+            <md-menu-item @click="fullScreen(w)" v-else-if="!w.standalone">
+              <span>Fullscreen</span>
+              <md-icon>fullscreen</md-icon>
+            </md-menu-item>
+            <md-menu-item @click="detach(w)" v-if="!w.standalone">
+              <span>Detach</span>
+              <md-icon>launch</md-icon>
+            </md-menu-item>
+            <md-menu-item @click="duplicate(w)">
+              <span>Duplicate</span>
+              <md-icon>filter</md-icon>
+            </md-menu-item>
+            <md-menu-item @click="close(w)">
+              <span>Close</span>
+              <md-icon>close</md-icon>
+            </md-menu-item>
+            <md-menu-item @click="printObject(w.type, w.data, w)">
+              <span>Console.log</span>
+              <md-icon>bug_report</md-icon>
+            </md-menu-item>
+            <md-menu-item
+              v-for="(loader, name) in w.loaders"
+              :key="name"
+              @click="loaders && loaders[loader](w.data)"
+            >
+              <span>{{ name }}</span>
+              <md-icon>play_arrow</md-icon>
+            </md-menu-item>
+          </md-menu-content>
+        </md-menu>
+      </div>
+    </md-card-actions>
+
     <md-card-content
       :class="w.standalone ? 'taller-container' : 'shorter-container'"
       class="plugin-iframe-container allow-scroll"

--- a/web/src/components/windows/PluginEditorWindow.vue
+++ b/web/src/components/windows/PluginEditorWindow.vue
@@ -29,7 +29,7 @@ export default {
   },
   mounted() {
     if (this.w.data.engine_file_obj) {
-      this.$refs.code_editor.openEnigneFile(this.w.data.engine_file_obj);
+      this.$refs.code_editor.openEngineFile(this.w.data.engine_file_obj);
     }
   },
   methods: {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1035,24 +1035,29 @@ export class PluginManager {
       if (p.type !== "native-python") {
         continue;
       }
-      if (p.engine_mode === engine.id) {
-        await this.reloadPlugin(p);
-      } else if (!p.engine_mode || p.engine_mode === "auto") {
-        const running_plugins =
-          Object.values(this.plugins).filter(pl => {
-            return pl.name === p.name;
-          }) || [];
+      try {
+        if (p.engine_mode === engine.id) {
+          await this.reloadPlugin(p);
+        } else if (!p.engine_mode || p.engine_mode === "auto") {
+          const running_plugins =
+            Object.values(this.plugins).filter(pl => {
+              return pl.name === p.name;
+            }) || [];
 
-        const running_plugin = running_plugins[0];
-        if (
-          running_plugin &&
-          (!running_plugin.config.engine ||
-            (!running_plugin.initializing && running_plugin._disconnected))
-        ) {
-          await this.reloadPlugin(p);
-        } else if (!running_plugin) {
-          await this.reloadPlugin(p);
+          const running_plugin = running_plugins[0];
+          if (
+            running_plugin &&
+            (!running_plugin.config.engine ||
+              (!running_plugin.initializing && running_plugin._disconnected))
+          ) {
+            await this.reloadPlugin(p);
+          } else if (!running_plugin) {
+            await this.reloadPlugin(p);
+          }
         }
+      } catch (e) {
+        console.error(e);
+        continue;
       }
     }
   }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -2127,16 +2127,13 @@ export class PluginManager {
         if (plugin.config.origin) {
           this.checkPluginUpdate(plugin);
         } else {
-          const ps = this.available_plugins.filter(p => {
+          const pc = this.available_plugins.find(p => {
             return plugin.name === p.name;
           });
-          if (ps.length > 0) {
-            plugin.config.origin = ps[0].uri;
+          if (pc) {
+            plugin.config.origin = pc.uri;
             this.checkPluginUpdate(plugin);
           }
-          // else{
-          //   console.log(`Plugin origin not found: ${plugin.name}`)
-          // }
         }
       }
     }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1,5 +1,6 @@
 /*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_plugin$" }]*/
 import PouchDB from "pouchdb-browser";
+import SparkMD5 from "spark-md5";
 import axios from "axios";
 import _ from "lodash";
 
@@ -12,6 +13,7 @@ import {
   githubRepo,
   githubUrlRaw,
   assert,
+  compareVersions,
 } from "./utils.js";
 
 import { parseComponent } from "./pluginParser.js";
@@ -638,6 +640,16 @@ export class PluginManager {
               if (config.workflow) {
                 this.workflow_list.push(config);
               } else {
+                //verify hash
+                if (config.hash) {
+                  if (SparkMD5.hash(config.code) !== config.hash) {
+                    console.error(
+                      "Plugin source code signature mismatch, skip loading plugin",
+                      config
+                    );
+                    continue;
+                  }
+                }
                 config.installed = true;
                 this.installed_plugins.push(config);
                 if (skip_native_python && config.type === "native-python") {
@@ -726,11 +738,12 @@ export class PluginManager {
       throw "failed to get code.";
     }
     const code = response.data;
-    let config = this.parsePluginCode(code, { tag: selected_tag });
-    config.uri = uri;
-    config.origin = uri;
+    let config = this.parsePluginCode(code, {
+      tag: selected_tag,
+      origin: uri,
+      uri: uri,
+    });
     config.scoped_plugins = scoped_plugins;
-    config.tag = selected_tag;
     return config;
   }
 
@@ -978,6 +991,7 @@ export class PluginManager {
         });
         template.code = code;
         template._id = template.name.replace(/ /g, "_");
+        template.hash = SparkMD5.hash(template.code);
         const addPlugin = template => {
           this.db
             .put(template)
@@ -1067,41 +1081,32 @@ export class PluginManager {
 
   parsePluginCode(code, overwrite_config) {
     let config = {};
-    const uri = overwrite_config.uri;
     try {
-      if (uri && uri.endsWith(".js")) {
-        config.lang = "javascript";
-        config.scripts = [code];
-        config.script = code;
-        config.style = null;
-        config.window = null;
-        config.tag = overwrite_config.tag || null;
-      } else {
-        const pluginComp = parseComponent(code);
-        config = JSON.parse(pluginComp.config[0].content);
-        config.scripts = [];
-        for (let i = 0; i < pluginComp.script.length; i++) {
-          config.scripts.push(pluginComp.script[i]);
-        }
-        if (!config.script) {
-          config.script = pluginComp.script[0].content;
-        }
-        config.tag = overwrite_config.tag || (config.tags && config.tags[0]);
-        // try to match the script with current tag
-        for (let i = 0; i < pluginComp.script.length; i++) {
-          if (pluginComp.script[i].attrs.tag === config.tag) {
-            config.script = pluginComp.script[i].content;
-            break;
-          }
-        }
-        config.links = pluginComp.link || null;
-        config.windows = pluginComp.window || null;
-        config.styles = pluginComp.style || null;
-        config.docs = pluginComp.docs || null;
-        config.attachments = pluginComp.attachment || null;
+      const pluginComp = parseComponent(code);
+      config = JSON.parse(pluginComp.config[0].content);
+      config.scripts = [];
+      for (let i = 0; i < pluginComp.script.length; i++) {
+        config.scripts.push(pluginComp.script[i]);
       }
-      config._id = overwrite_config._id || null;
-      config.uri = uri;
+      if (!config.script) {
+        config.script = pluginComp.script[0].content;
+      }
+      config.tag = overwrite_config.tag || (config.tags && config.tags[0]);
+      // try to match the script with current tag
+      for (let i = 0; i < pluginComp.script.length; i++) {
+        if (pluginComp.script[i].attrs.tag === config.tag) {
+          config.script = pluginComp.script[i].content;
+          break;
+        }
+      }
+      config.links = pluginComp.link || null;
+      config.windows = pluginComp.window || null;
+      config.styles = pluginComp.style || null;
+      config.docs = pluginComp.docs || null;
+      config.attachments = pluginComp.attachment || null;
+
+      config._id = overwrite_config._id || config.name.replace(/ /g, "_");
+      config.uri = overwrite_config.uri;
       config.origin = overwrite_config.origin;
       config.code = code;
       config.id = config.name.trim().replace(/ /g, "_") + "_" + randId();
@@ -2083,5 +2088,37 @@ export class PluginManager {
 
   onClose(_plugin, cb) {
     _plugin.onClose(cb);
+  }
+
+  checkUpdates() {
+    for (let k in this.plugins) {
+      if (this.plugins.hasOwnProperty(k)) {
+        const plugin = this.plugins[k];
+        const pconfig = plugin.config;
+        if (pconfig.origin) {
+          this.getPluginFromUrl(pconfig.origin, this.available_plugins).then(
+            async config => {
+              if (pconfig.hash) {
+                if (pconfig.hash !== SparkMD5.hash(config.code)) {
+                  if (compareVersions(pconfig.version, "<=", config.version)) {
+                    plugin.update_available = true;
+                  } else {
+                    plugin.update_available = false;
+                  }
+                } else {
+                  plugin.update_available = false;
+                }
+              } else {
+                if (compareVersions(pconfig.version, "<", config.version)) {
+                  plugin.update_available = true;
+                } else {
+                  plugin.update_available = false;
+                }
+              }
+            }
+          );
+        }
+      }
+    }
   }
 }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -2090,33 +2090,37 @@ export class PluginManager {
     _plugin.onClose(cb);
   }
 
+  async checkPluginUpdate(plugin) {
+    const pconfig = plugin.config;
+    const config = await this.getPluginFromUrl(
+      pconfig.origin,
+      this.available_plugins
+    );
+    if (pconfig.hash) {
+      if (pconfig.hash !== SparkMD5.hash(config.code)) {
+        if (compareVersions(pconfig.version, "<=", config.version)) {
+          plugin.update_available = true;
+        } else {
+          plugin.update_available = false;
+        }
+      } else {
+        plugin.update_available = false;
+      }
+    } else {
+      if (compareVersions(pconfig.version, "<", config.version)) {
+        plugin.update_available = true;
+      } else {
+        plugin.update_available = false;
+      }
+    }
+    this.update_ui_callback();
+  }
   checkUpdates() {
     for (let k in this.plugins) {
       if (this.plugins.hasOwnProperty(k)) {
         const plugin = this.plugins[k];
-        const pconfig = plugin.config;
-        if (pconfig.origin) {
-          this.getPluginFromUrl(pconfig.origin, this.available_plugins).then(
-            async config => {
-              if (pconfig.hash) {
-                if (pconfig.hash !== SparkMD5.hash(config.code)) {
-                  if (compareVersions(pconfig.version, "<=", config.version)) {
-                    plugin.update_available = true;
-                  } else {
-                    plugin.update_available = false;
-                  }
-                } else {
-                  plugin.update_available = false;
-                }
-              } else {
-                if (compareVersions(pconfig.version, "<", config.version)) {
-                  plugin.update_available = true;
-                } else {
-                  plugin.update_available = false;
-                }
-              }
-            }
-          );
+        if (plugin.config.origin) {
+          this.checkPluginUpdate(plugin);
         }
       }
     }

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -2121,6 +2121,17 @@ export class PluginManager {
         const plugin = this.plugins[k];
         if (plugin.config.origin) {
           this.checkPluginUpdate(plugin);
+        } else {
+          const ps = this.available_plugins.filter(p => {
+            return plugin.name === p.name;
+          });
+          if (ps.length > 0) {
+            plugin.config.origin = ps[0].uri;
+            this.checkPluginUpdate(plugin);
+          }
+          // else{
+          //   console.log(`Plugin origin not found: ${plugin.name}`)
+          // }
         }
       }
     }

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -10,6 +10,14 @@ export function assert(condition, message) {
   }
 }
 
+export function isTouchDevice() {
+  return (
+    "ontouchstart" in window ||
+    navigator.MaxTouchPoints > 0 ||
+    navigator.msMaxTouchPoints > 0
+  );
+}
+
 export function compareVersions(v1, comparator, v2) {
   comparator = comparator == "=" ? "==" : comparator;
   if (


### PR DESCRIPTION
This PR introduce hash to plugin code and use it to verify plugin updates.

A "NEW" badge will show if there is new version available:

<img width="352" alt="Screen Shot 2019-06-15 at 7 55 35 PM" src="https://user-images.githubusercontent.com/478667/59558464-92665080-8fa7-11e9-870b-1958d1ac0e6d.png">

Also fixed a few bugs:

 * stop loading python plugin when one of them failed.
 * a typo for `openEngineFile` (thanks to @MartinHjelmare )
 * code editor bug
 * simplify the window title bar
 * preserve origin when editing the plugin file
 * clean up `parsePluginCode`