### PR TITLE
Propose restart the app if loading takes too long

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -68,6 +68,21 @@
           if(window.location.hash && window.location.hash !== '#/' ){
             removeWelcomePage()
           }
+
+          //propose to restart if it takes too long to load the page
+          function reload(){
+            var elem = document.getElementById("loading-imjoy-section");
+            if(elem){
+              var ret = confirm("It takes too long to load the app, would you like to restart?");
+              if(ret){
+                window.location.reload(true);
+              }
+              else{
+                setTimeout(reload, 10000);
+              }
+            }
+          }
+          setTimeout(reload, 10000);
       })();
     </script>
 

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -150,7 +150,8 @@
           >).
         </p>
         <p>
-          Once installed, please start the Plugin Engine, and fill the connection token below.
+          Once installed, please start the Plugin Engine, and fill the
+          connection token below.
         </p>
         <div v-if="!is_mobile_or_tablet">
           <md-radio v-model="url_type" value="localhost">My Computer</md-radio>

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -150,8 +150,7 @@
           >).
         </p>
         <p>
-          If you have it already, please start the Plugin Engine, and connect to
-          it.
+          Once installed, please start the Plugin Engine, and fill the connection token below.
         </p>
         <div v-if="!is_mobile_or_tablet">
           <md-radio v-model="url_type" value="localhost">My Computer</md-radio>

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -201,18 +201,25 @@
                 <md-icon>library_books</md-icon>Documentation
               </md-menu-item>
               <md-menu-item
-                href="https://github.com/oeway/ImJoy"
+                href="/docs/#/api?id=api-functions"
                 target="_blank"
                 class="md-primary"
               >
-                <md-icon>code</md-icon>Github
+                <md-icon>toc</md-icon>API Functions
               </md-menu-item>
               <md-menu-item
                 href="https://forum.image.sc/tags/imjoy"
                 target="_blank"
                 class="md-primary"
               >
-                <md-icon>help</md-icon>Help
+                <md-icon>help</md-icon>Forum
+              </md-menu-item>
+              <md-menu-item
+                href="https://github.com/oeway/ImJoy"
+                target="_blank"
+                class="md-primary"
+              >
+                <md-icon>code</md-icon>Github
               </md-menu-item>
               <md-menu-item @click="showAboutDialog = true" class="md-primary">
                 <md-icon>info</md-icon>About


### PR DESCRIPTION
* For some reason the PWA installed in IOS can stuck forever, and there is no easy way to get it restarted except clear browser cache. This is a fix for it, if the page stuck for more than 10s, it will popup a dialog to propose restart the app.


* a couple of other improvements: add api document button, improve engine dialog text etc.
