### PR TITLE
Enable allow-same-origin to support devices camera/microphone and offline plugins

### DIFF
--- a/utils/scripts/deploy.sh
+++ b/utils/scripts/deploy.sh
@@ -45,3 +45,38 @@ git diff-index --quiet HEAD || git commit -m "Deploy to GitHub Pages $TARGET_BRA
 
 # Now that we're all set up, we can push.
 git push $SSH_REPO $TARGET_BRANCH
+
+# ======== deploy imjoy-lib with jailed library ========
+LIB_REPO=git@github.com:oeway/lib.imjoy.io.git
+cd ../
+git clone $LIB_REPO imjoy-lib
+cd imjoy-lib
+
+# Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deploy).
+git checkout master || { git checkout --orphan master; git rm -rf .; }
+
+# Clean up
+rm -rf ./*
+
+# Copy dirs and files and that we want to update.
+cp -Rf ../web/dist/*  ./
+rm -rf ./static/*
+rm -rf ./docs
+rm -rf CNAME
+rm -rf index.html
+cp -Rf ../web/dist/static/icons ./static/icons
+cp -Rf ../web/dist/static/iconfont ./static/iconfont
+cp -Rf ../web/dist/static/jailed ./static/jailed
+
+# Create .nojekyll to bypass Github jekyll
+touch .nojekyll
+echo "lib.imjoy.io" > CNAME
+
+# Commit the "changes", i.e. the new version.
+# The delta will show diffs between new and old versions.
+git add -A .
+git diff-index --quiet HEAD || git commit -m "Deploy to GitHub Pages $TARGET_BRANCH branch: ${SHA}"
+
+LIB_SSH_REPO=${LIB_REPO/https:\/\/github.com\//git@github.com:}
+# Now that we're all set up, we can push.
+git push $LIB_SSH_REPO master

--- a/utils/scripts/deploy.sh
+++ b/utils/scripts/deploy.sh
@@ -75,7 +75,7 @@ echo "lib.imjoy.io" > CNAME
 # Commit the "changes", i.e. the new version.
 # The delta will show diffs between new and old versions.
 git add -A .
-git diff-index --quiet HEAD || git commit -m "Deploy to GitHub Pages $TARGET_BRANCH branch: ${SHA}"
+git diff-index --quiet HEAD || git commit -m "Deploy to GitHub Pages master branch: ${SHA}"
 
 LIB_SSH_REPO=${LIB_REPO/https:\/\/github.com\//git@github.com:}
 # Now that we're all set up, we can push.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.81",
+  "version": "0.9.82",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/plugin-service-worker.js
+++ b/web/public/plugin-service-worker.js
@@ -1,0 +1,56 @@
+/* eslint-disable */
+importScripts("https://storage.googleapis.com/workbox-cdn/releases/3.6.3/workbox-sw.js");
+
+if (workbox) {
+  console.log(`Workbox is loaded`);
+  /**
+   * The workboxSW.precacheAndRoute() method efficiently caches and responds to
+   * requests for URLs in the manifest.
+   * See https://goo.gl/S9QRab
+   */
+
+  // workbox.setConfig({
+  //   debug: true
+  // });
+
+  workbox.core.setCacheNameDetails({ prefix: "lib.imjoy.io" });
+  self.__precacheManifest = self.__precacheManifest || [];
+
+  workbox.precaching.suppressWarnings();
+  workbox.precaching.precacheAndRoute(self.__precacheManifest, {});
+
+  workbox.routing.registerRoute(
+    new RegExp("/static/.*"),
+    new workbox.strategies.NetworkFirst()
+  );
+
+  //communitations
+  workbox.routing.registerRoute(
+    new RegExp("(http|https)://.*/socket.io/.*"),
+    new workbox.strategies.NetworkOnly()
+  );
+
+  workbox.routing.registerRoute(
+    new RegExp("https://static.imjoy.io/.*"),
+    new workbox.strategies.NetworkFirst()
+  );
+
+  // manifest.imjoy.json etc.
+  workbox.routing.registerRoute(
+    new RegExp("https://raw.githubusercontent.com/.*"),
+    new workbox.strategies.NetworkFirst()
+  );
+
+  workbox.routing.registerRoute(
+    new RegExp("https://gist.githubusercontent.com/.*"),
+    new workbox.strategies.NetworkFirst()
+  );
+
+  workbox.routing.setDefaultHandler(new workbox.strategies.NetworkOnly());
+
+  self.addEventListener("message", e => {
+    if (e.data.action == "skipWaiting") self.skipWaiting();
+  });
+} else {
+  console.log(`Workbox didn't load`);
+}

--- a/web/src/jailed/_frame.js
+++ b/web/src/jailed/_frame.js
@@ -239,15 +239,23 @@ if (plugin_mode === "web-worker") {
 }
 
 // register service worker for offline access
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', function() {
-      var workspace = getParamValue("workspace") || 'default';
-      navigator.serviceWorker.register('/plugin-service-worker.js', {scope: './'+workspace+'/'}).then(function(registration) {
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", function() {
+    var workspace = getParamValue("workspace") || "default";
+    navigator.serviceWorker
+      .register("/plugin-service-worker.js", { scope: "./" + workspace + "/" })
+      .then(
+        function(registration) {
           // Registration was successful
-          console.log('ServiceWorker registration successful with scope: ', registration.scope);
-      }, function(err) {
+          console.log(
+            "ServiceWorker registration successful with scope: ",
+            registration.scope
+          );
+        },
+        function(err) {
           // registration failed :(
-          console.log('ServiceWorker registration failed: ', err);
-      });
+          console.log("ServiceWorker registration failed: ", err);
+        }
+      );
   });
 }

--- a/web/src/jailed/_frame.js
+++ b/web/src/jailed/_frame.js
@@ -237,3 +237,17 @@ if (plugin_mode === "web-worker") {
   console.error("Unsupported plugin type: " + plugin_mode);
   throw "Unsupported plugin type: " + plugin_mode;
 }
+
+// register service worker for offline access
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', function() {
+      var workspace = getParamValue("workspace") || 'default';
+      navigator.serviceWorker.register('/plugin-service-worker.js', {scope: './'+workspace+'/'}).then(function(registration) {
+          // Registration was successful
+          console.log('ServiceWorker registration successful with scope: ', registration.scope);
+      }, function(err) {
+          // registration failed :(
+          console.log('ServiceWorker registration failed: ', err);
+      });
+  });
+}

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -344,7 +344,13 @@ var basicConnectionWeb = function() {
       if (!me._disconnected) {
         me._frame = sample.cloneNode(false);
         me._frame.src =
-          me._frame.src + "?type=" + type + "&name=" + config.name + "&workspace=" + config.workspace;
+          me._frame.src +
+          "?type=" +
+          type +
+          "&name=" +
+          config.name +
+          "&workspace=" +
+          config.workspace;
         me._frame.id = "iframe_" + id;
         if (
           type == "iframe" ||

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -344,7 +344,7 @@ var basicConnectionWeb = function() {
       if (!me._disconnected) {
         me._frame = sample.cloneNode(false);
         me._frame.src =
-          me._frame.src + "?type=" + type + "&name=" + config.name;
+          me._frame.src + "?type=" + type + "&name=" + config.name + "&workspace=" + config.workspace;
         me._frame.id = "iframe_" + id;
         if (
           type == "iframe" ||

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -37,9 +37,13 @@ if (__is__node__) {
   __jailed__path__ = __dirname + "/";
 } else {
   // web
-  __jailed__path__ = `${location.protocol}//${location.hostname}${
-    location.port ? ":" + location.port : ""
-  }/static/jailed/`;
+  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+    __jailed__path__ = `${location.protocol}//${location.hostname}${
+      location.port ? ":" + location.port : ""
+    }/static/jailed/`;
+  } else {
+    __jailed__path__ = "//lib.imjoy.io/static/jailed/";
+  }
   // var scripts = document.getElementsByTagName("script");
   // __jailed__path__ = scripts[scripts.length-1].src
   //     .split('?')[0]
@@ -292,7 +296,13 @@ var basicConnectionNode = function() {
  * web-browser environment
  */
 var basicConnectionWeb = function() {
-  var perm = ["allow-scripts", "allow-forms"];
+  var perm = [
+    "allow-scripts",
+    "allow-forms",
+    "allow-same-origin",
+    "allow-modals",
+    "allow-popups",
+  ];
 
   if (__jailed__path__.substr(0, 7).toLowerCase() == "file://") {
     // local instance requires extra permission
@@ -303,6 +313,10 @@ var basicConnectionWeb = function() {
   var sample = document.createElement("iframe");
   sample.src = __jailed__path__ + "_frame.html";
   sample.sandbox = perm.join(" ");
+  sample.allow =
+    "midi *; geolocation *; microphone *; camera *; encrypted-media *;";
+  sample.allowfullscreen = "";
+  sample.allowpaymentrequest = "";
   sample.frameBorder = "0";
   sample.style.width = "100%";
   sample.style.height = "100%";


### PR DESCRIPTION
This PR adds allow-same-origin to the sandboxed iframe used in ImJoy, a key challenge is to maintain the isolation between the main app and untrusted plugins. By hosting the iframe source files from another origin (lib.imjoy.io), the isolation still works and we can then enable the `allow-same-origin` option. After adding that, cameras, microphone etc will be enabled automatically. We can also add offline support for plugins since we can have a service-worker inside the iframe.

(Note: websites such as https://jsfiddle.net is using the same way to enable allow-same-origin )

Offline access for plugins requires more work, will be supported in another PR.