### PR TITLE
Update window layout during fullscreen

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -377,7 +377,6 @@ For more details see the dedicated [section](development?id=virtual-environments
 
 #### permissions
 For `window` plugins, the following permissions can be decleared:
- * same-origin
  * camera
  * midi
  * geolocation
@@ -385,6 +384,7 @@ For `window` plugins, the following permissions can be decleared:
  * encrypted-media
  * full-screen
  * payment-request
+ * same-origin
 
  For example, if your window plugin requires webcam access, add the following permission:
  ```

--- a/utils/scripts/deploy-lib.sh
+++ b/utils/scripts/deploy-lib.sh
@@ -31,7 +31,7 @@ cd imjoy-lib
 git checkout ${LIB_TARGET_BRANCH} || { git checkout --orphan ${LIB_TARGET_BRANCH}; git rm -rf .; }
 
 # Remove all existing files
-ls -A1 | xargs rm -rf
+ls -A1 | grep -v '.git' | xargs rm -rf
 
 # Copy dirs and files and that we want to update.
 cp -Rf ../web/dist/*  ./

--- a/utils/scripts/deploy.sh
+++ b/utils/scripts/deploy.sh
@@ -33,7 +33,7 @@ git config user.name "Travis CI"
 git config user.email "travis@travis-ci.org"
 
 # Remove all existing files
-ls -A1 | xargs rm -rf
+ls -A1 | grep -v '.git' | xargs rm -rf
 
 # Copy dirs and files and that we want to update.
 cp -Rf ../web/dist/* ./

--- a/web/src/components/Whiteboard.vue
+++ b/web/src/components/Whiteboard.vue
@@ -26,6 +26,7 @@
       :vertical-compact="true"
       :margin="[3, 3]"
       :use-css-transforms="true"
+      ref="window_grid"
     >
       <grid-item
         :key="w.id"
@@ -262,6 +263,7 @@ export default {
       w._w = w.w;
       w.h = fh;
       w.w = fw;
+      this.$refs.window_grid.layoutUpdate();
       setTimeout(() => {
         w.resize && w.resize();
         w.refresh();
@@ -277,6 +279,7 @@ export default {
       w.w = w._w || 5;
       w._w = null;
       w._h = null;
+      this.$refs.window_grid.layoutUpdate();
       setTimeout(() => {
         w.resize && w.resize();
         w.refresh();


### PR DESCRIPTION
When the plugin window is toggling between normal view and full screen model, the layout didn't get updated properly and it often cause windows to overlap.

This PR fixes #221