### PR TITLE
add allow-same-origin by default

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -384,7 +384,6 @@ For `window` plugins, the following permissions can be decleared:
  * encrypted-media
  * full-screen
  * payment-request
- * same-origin
 
  For example, if your window plugin requires webcam access, add the following permission:
  ```

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -212,15 +212,16 @@ var basicConnectionWeb = function() {
           "allow-forms",
           "allow-modals",
           "allow-popups",
+          "allow-same-origin",
         ];
         var allows = "";
-        if (
-          __jailed__path__.substr(0, 7).toLowerCase() == "file://" &&
-          !perm.includes("allow-same-origin")
-        ) {
-          // local instance requires extra permission
-          perm.push("allow-same-origin");
-        }
+        // if (
+        //   __jailed__path__.substr(0, 7).toLowerCase() == "file://" &&
+        //   !perm.includes("allow-same-origin")
+        // ) {
+        //   // local instance requires extra permission
+        //   perm.push("allow-same-origin");
+        // }
         if (config.permissions) {
           if (
             config.permissions.includes("midi") &&
@@ -251,12 +252,6 @@ var basicConnectionWeb = function() {
             !allows.includes("encrypted-media *;")
           ) {
             allows += "encrypted-media *;";
-          }
-          if (
-            (allows || config.permissions.includes("same-origin")) &&
-            !perm.includes("allow-same-origin")
-          ) {
-            perm.push("allow-same-origin");
           }
           if (config.permissions.includes("full-screen")) {
             me._frame.allowfullscreen = "";


### PR DESCRIPTION
Service worker was blocked because we don't have `allow-same-origin` by default in the sandboxed plugin iframe.

It complains about:
`Uncaught SecurityError: Failed to read the 'serviceWorker' property from 'Navigator': Service worker is disabled because the context is sandboxed and lacks the 'allow-same-origin' flag.
`
A quick fix is to `allow-same-origin` by default in the plugin iframe.

Notice that the app on ImJoy.io should be still secured because the iframe will be loaded from another origin (lib.imjoy.io), so the isolation still maintains.