### PR TITLE
Fix ios webworker and improve imjoy-lite

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -384,7 +384,6 @@ For `window` plugins, the following permissions can be decleared:
  * encrypted-media
  * full-screen
  * payment-request
- * same-origin
 
  For example, if your window plugin requires webcam access, add the following permission:
  ```

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.9.84",
+  "version": "0.9.85",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/public/lite.html
+++ b/web/public/lite.html
@@ -248,10 +248,14 @@
                 },
                 update_ui_callback: ()=>{}
             })
-            imjoy.start().then(()=>{
+            const workspace = getUrlParameter('workspace') || getUrlParameter('w');
+            const token = getUrlParameter('token') || getUrlParameter('t');
+            const engine = getUrlParameter('engine') || getUrlParameter('e');
+
+            imjoy.start({workspace: workspace, engine: engine, token:token}).then(()=>{
                 windows = imjoy.wm.windows
-                console.log(imjoy)
-                let p = getUrlParameter('plugin');
+                console.log('ImJoy started: ', imjoy)
+                let p = getUrlParameter('plugin') || getUrlParameter('p');
                 p = p || prompt(`Please type a ImJoy plugin URI to start or pass it with ${window.location.href+'?plugin=XXXXX'}`, 'oeway/ImJoy-Plugins:Welcome');
                 p = p || 'oeway/ImJoy-Plugins:Welcome';
                 if(p){

--- a/web/public/lite.html
+++ b/web/public/lite.html
@@ -80,10 +80,16 @@
         .pointer{
             cursor: pointer;
         }
+        #empty-img {
+            width: 128px;
+            position: absolute !important;
+            left: calc(50% - 64px) !important;
+            top: calc(40% - 64px) !important;
+        }
         .floating {
             position: absolute !important;
-            left: calc(50% - 1.5rem) !important;
-            top: calc(39% - 1.5rem) !important;
+            left: calc(50% - 2px) !important;
+            top: calc(39% - 20px) !important;
             z-index: 999;
         }
     </style>
@@ -127,7 +133,9 @@
         <progress class="progress" id="progress" value="100" max="100"></progress>
     </header>
     <div class="loading loading-lg floating" id="loading"></div>
-    <div class="whiteboard" id="whiteboard"></div>
+    <div class="whiteboard" id="whiteboard">
+        <img src="static/img/imjoy-io-icon.svg" id="empty-img">
+    </div>
 
     <script>
         function openDialog() {
@@ -156,12 +164,18 @@
                 <div class="window_container" id="${id}"></div>
             ` + document.getElementById('whiteboard').innerHTML;
 
+            if(document.getElementById('empty-img'))
+            document.getElementById('whiteboard').removeChild(document.getElementById('empty-img'));
+
             selectWindow(id)
         }
 
         function removeWindow(id){
             document.getElementById('header').removeChild(document.getElementById('header_'+id));
             document.getElementById('whiteboard').removeChild(document.getElementById(id));
+            if(document.getElementById('whiteboard').children.length === 0){
+                document.getElementById('whiteboard').innerHTML = `<img src="static/img/imjoy-io-icon.svg" id="empty-img">`
+            }
         }
 
         function selectWindow(id){

--- a/web/public/lite.html
+++ b/web/public/lite.html
@@ -75,6 +75,7 @@
             height: 100%;
         }
         .site-title-small{
+            margin-left: 3px;
             height: 32px;
         }
         .pointer{
@@ -97,10 +98,10 @@
 
 <body>
     <div class="modal" id="dialog-container">
-        <a href="#close" class="modal-overlay" aria-label="Close"></a>
+        <a href="#" class="modal-overlay" aria-label="Close"></a>
         <div class="modal-container">
             <div class="modal-header">
-                <a href="#close" class="btn btn-clear float-right" aria-label="Close"
+                <a href="#" class="btn btn-clear float-right" aria-label="Close"
                     onclick="closeDialog()"></a>
                 <div class="modal-title h5" id="window-dialog-title">Dialog</div>
             </div>
@@ -114,11 +115,13 @@
     </div>
     <header class="navbar">
         <section class="navbar-section">
-            <img
+            <a href="/">
+                <img
                 class="site-title-small"
-                src="https://imjoy.io/static/img/imjoy-logo-black.svg"
+                src="static/img/imjoy-logo-black.svg"
                 alt="ImJoy"
-            />
+                />
+            </a>
             <!-- <a href="https://imjoy.io/docs" target="_blank" class="btn btn-link">Docs</a>
             <a href="https://github.com/oeway/ImJoy" target="_blank" class="btn btn-link">GitHub</a> -->
         </section>
@@ -164,27 +167,25 @@
                 <div class="window_container" id="${id}"></div>
             ` + document.getElementById('whiteboard').innerHTML;
 
-            if(document.getElementById('empty-img'))
-            document.getElementById('whiteboard').removeChild(document.getElementById('empty-img'));
-
             selectWindow(id)
         }
 
         function removeWindow(id){
             document.getElementById('header').removeChild(document.getElementById('header_'+id));
             document.getElementById('whiteboard').removeChild(document.getElementById(id));
-            if(document.getElementById('whiteboard').children.length === 0){
-                document.getElementById('whiteboard').innerHTML = `<img src="static/img/imjoy-io-icon.svg" id="empty-img">`
+            if(document.getElementById('whiteboard').children.length === 1){
+                document.getElementById('empty-img').style.display = 'block';
             }
         }
 
         function selectWindow(id){
+            if(!document.getElementById(id))
+            return
             for(let c of document.getElementById('whiteboard').children){
                 if(c.id !== 'site-title'){
                     c.style.display = "none";
                 }
             } 
-
             for(let c of document.getElementById('header').children)
                 c.classList.remove('active')
             selected_window = id;
@@ -270,6 +271,10 @@
                 windows = imjoy.wm.windows
                 console.log('ImJoy started: ', imjoy)
                 let p = getUrlParameter('plugin') || getUrlParameter('p');
+                if(!p && workspace){
+                    document.getElementById('loading').style.display = 'none';
+                    return
+                }
                 p = p || prompt(`Please type a ImJoy plugin URI to start or pass it with ${window.location.href+'?plugin=XXXXX'}`, 'oeway/ImJoy-Plugins:Welcome');
                 p = p || 'oeway/ImJoy-Plugins:Welcome';
                 if(p){

--- a/web/src/imjoyLib.js
+++ b/web/src/imjoyLib.js
@@ -105,15 +105,26 @@ export class ImJoy {
     }
   }
 
-  async start(workspace) {
+  async start(config) {
     await this.init();
-    await this.pm.loadWorkspace(workspace);
-    await this.pm.reloadPlugins(false);
-    const connections = this.em.connectAll(true);
+    if (config.workspace) {
+      await this.pm.loadWorkspace(config.workspace);
+      await this.pm.reloadPlugins(false);
+    }
+
     try {
-      await connections;
+      if (config.engine) {
+        await this.em.addEngine(
+          { type: "default", url: config.engine, token: config.token },
+          false
+        );
+        await this.em.getEngineByUrl(config.engine).connect();
+      } else {
+        const connections = this.em.connectAll(true);
+        await connections;
+      }
     } catch (e) {
-      console.error(e);
+      console.error("Failed to connect the plugin engine(s)", e);
     }
   }
 

--- a/web/src/jailed/_JailedSite.js
+++ b/web/src/jailed/_JailedSite.js
@@ -597,7 +597,7 @@
         } else if (v instanceof Error) {
           console.error(v);
           bObject[k] = { __jailed_type__: "error", __value__: v.toString() };
-        } else if (typeof File !== 'undefined' && v instanceof File) {
+        } else if (typeof File !== "undefined" && v instanceof File) {
           bObject[k] = {
             __jailed_type__: "file",
             __value__: v,

--- a/web/src/jailed/_JailedSite.js
+++ b/web/src/jailed/_JailedSite.js
@@ -597,7 +597,7 @@
         } else if (v instanceof Error) {
           console.error(v);
           bObject[k] = { __jailed_type__: "error", __value__: v.toString() };
-        } else if (v instanceof File) {
+        } else if (typeof File !== 'undefined' && v instanceof File) {
           bObject[k] = {
             __jailed_type__: "file",
             __value__: v,

--- a/web/src/jailed/_pluginNode.js
+++ b/web/src/jailed/_pluginNode.js
@@ -69,8 +69,12 @@ var importScript = function(url) {
     process.send({ type: "importSuccess", url: url });
   };
 
-  var fCb = function() {
-    process.send({ type: "importFailure", url: url });
+  var fCb = function(error) {
+    process.send({
+      type: "importFailure",
+      url: url,
+      error: error.stack || String(error),
+    });
   };
 
   var run = function(code) {
@@ -84,7 +88,7 @@ var importScript = function(url) {
       run(loadLocal(url));
     } catch (e) {
       printError(e.stack);
-      fCb();
+      fCb(e);
     }
   }
 };
@@ -100,8 +104,12 @@ var importScriptJailed = function(url) {
     process.send({ type: "importSuccess", url: url });
   };
 
-  var fCb = function() {
-    process.send({ type: "importFailure", url: url });
+  var fCb = function(error) {
+    process.send({
+      type: "importFailure",
+      url: url,
+      error: error.stack || String(error),
+    });
   };
 
   var run = function(code) {
@@ -115,7 +123,7 @@ var importScriptJailed = function(url) {
       run(loadLocal(url));
     } catch (e) {
       printError(e.stack);
-      fCb();
+      fCb(e);
     }
   }
 };
@@ -132,7 +140,7 @@ var execute = function(code) {
   };
 
   var fCb = function(e) {
-    process.send({ type: "executeFailure", error: e.toString() });
+    process.send({ type: "executeFailure", error: e.stack || String(e) });
   };
 
   executeJailed(code, "DYNAMIC PLUGIN", sCb, fCb);
@@ -154,7 +162,7 @@ var executeNormal = function(code, url, sCb, fCb) {
     sCb();
   } catch (e) {
     printError(e.stack);
-    fCb();
+    fCb(e);
   }
 };
 
@@ -223,7 +231,7 @@ var loadRemote = function(url, sCb, fCb) {
         "HTTP responce status code: " +
         res.statusCode;
       printError(msg);
-      fCb();
+      fCb(msg);
     } else {
       var content = "";
       res.on("end", function() {
@@ -242,7 +250,7 @@ var loadRemote = function(url, sCb, fCb) {
       .on("error", fCb);
   } catch (e) {
     printError(e.stack);
-    fCb();
+    fCb(e);
   }
 };
 

--- a/web/src/jailed/_pluginWebIframe.js
+++ b/web/src/jailed/_pluginWebIframe.js
@@ -105,7 +105,7 @@ var importScript = function(url) {
 function _sendToServiceWorker(message) {
   return new Promise(function(resolve, reject) {
     if (!navigator.serviceWorker || !navigator.serviceWorker.register) {
-      reject("This browser doesn't support service workers");
+      reject("Service worker is not support.");
       return;
     }
     var messageChannel = new MessageChannel();

--- a/web/src/jailed/_pluginWebIframe.js
+++ b/web/src/jailed/_pluginWebIframe.js
@@ -78,11 +78,12 @@ var importScript = function(url) {
     );
   };
 
-  var failure = function() {
+  var failure = function(error) {
     parent.postMessage(
       {
         type: "importFailure",
         url: url,
+        error: error.stack || String(error),
       },
       "*"
     );
@@ -96,7 +97,7 @@ var importScript = function(url) {
   }
 
   if (error) {
-    failure();
+    failure(error);
     throw error;
   }
 };
@@ -230,7 +231,10 @@ var execute = async function(code) {
     parent.postMessage({ type: "executeSuccess" }, "*");
   } catch (e) {
     console.error("failed to execute scripts: ", code, e);
-    parent.postMessage({ type: "executeFailure", error: e.toString() }, "*");
+    parent.postMessage(
+      { type: "executeFailure", error: e.stack || String(e) },
+      "*"
+    );
   }
 };
 

--- a/web/src/jailed/_pluginWebPython.js
+++ b/web/src/jailed/_pluginWebPython.js
@@ -78,11 +78,12 @@ var importScript = function(url) {
     );
   };
 
-  var failure = function() {
+  var failure = function(error) {
     parent.postMessage(
       {
         type: "importFailure",
         url: url,
+        error: error.stack || String(error),
       },
       "*"
     );
@@ -96,7 +97,7 @@ var importScript = function(url) {
   }
 
   if (error) {
-    failure();
+    failure(error);
     throw error;
   }
 };
@@ -236,7 +237,10 @@ var execute = async function(code) {
     parent.postMessage({ type: "executeSuccess" }, "*");
   } catch (e) {
     console.error("failed to execute scripts: ", code, e);
-    parent.postMessage({ type: "executeFailure", error: e.toString() }, "*");
+    parent.postMessage(
+      { type: "executeFailure", error: e.stack || String(e) },
+      "*"
+    );
   }
 };
 

--- a/web/src/jailed/_pluginWebWorker.js
+++ b/web/src/jailed/_pluginWebWorker.js
@@ -49,7 +49,11 @@ self.connection = {};
     }
 
     if (error || typeof returned != "undefined") {
-      self.postMessage({ type: "importFailure", url: url, error: error });
+      self.postMessage({
+        type: "importFailure",
+        url: url,
+        error: error.stack || String(error),
+      });
       if (error) {
         throw error;
       }
@@ -167,7 +171,7 @@ self.connection = {};
       self.postMessage({ type: "executeSuccess" });
     } catch (e) {
       console.error("failed to execute scripts: ", code, e);
-      self.postMessage({ type: "executeFailure", error: e.toString() });
+      self.postMessage({ type: "executeFailure", error: e.stack || String(e) });
     }
   };
 

--- a/web/src/jailed/_pluginWebWorker.js
+++ b/web/src/jailed/_pluginWebWorker.js
@@ -65,7 +65,7 @@ self.connection = {};
   function _sendToServiceWorker(message) {
     return new Promise(function(resolve, reject) {
       if (!navigator.serviceWorker || !navigator.serviceWorker.register) {
-        reject("This browser doesn't support service workers");
+        reject("Service worker is not support.");
         return;
       }
       var messageChannel = new MessageChannel();

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -37,7 +37,10 @@ if (__is__node__) {
   __jailed__path__ = __dirname + "/";
 } else {
   // web
-  if (location.search.includes('debug_jailed=1') && (location.hostname === "localhost" || location.hostname === "127.0.0.1")) {
+  if (
+    location.search.includes("debug_jailed=1") &&
+    (location.hostname === "localhost" || location.hostname === "127.0.0.1")
+  ) {
     __jailed__path__ = `${location.protocol}//${location.hostname}${
       location.port ? ":" + location.port : ""
     }/static/jailed/`;

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -212,15 +212,16 @@ var basicConnectionWeb = function() {
           "allow-forms",
           "allow-modals",
           "allow-popups",
+          "allow-same-origin",
         ];
         var allows = "";
-        if (
-          __jailed__path__.substr(0, 7).toLowerCase() == "file://" &&
-          !perm.includes("allow-same-origin")
-        ) {
-          // local instance requires extra permission
-          perm.push("allow-same-origin");
-        }
+        // if (
+        //   __jailed__path__.substr(0, 7).toLowerCase() == "file://" &&
+        //   !perm.includes("allow-same-origin")
+        // ) {
+        //   // local instance requires extra permission
+        //   perm.push("allow-same-origin");
+        // }
         if (config.permissions) {
           if (
             config.permissions.includes("midi") &&
@@ -251,12 +252,6 @@ var basicConnectionWeb = function() {
             !allows.includes("encrypted-media *;")
           ) {
             allows += "encrypted-media *;";
-          }
-          if (
-            (allows || config.permissions.includes("same-origin")) &&
-            !perm.includes("allow-same-origin")
-          ) {
-            perm.push("allow-same-origin");
           }
           if (config.permissions.includes("full-screen")) {
             me._frame.allowfullscreen = "";

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -37,7 +37,7 @@ if (__is__node__) {
   __jailed__path__ = __dirname + "/";
 } else {
   // web
-  if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
+  if (location.search.includes('debug_jailed=1') && (location.hostname === "localhost" || location.hostname === "127.0.0.1")) {
     __jailed__path__ = `${location.protocol}//${location.hostname}${
       location.port ? ":" + location.port : ""
     }/static/jailed/`;

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -961,12 +961,14 @@ export class PluginManager {
                 null
               );
             }
-            this.reloadPlugin(config).then(plugin => {
-              resolve(plugin);
-            });
+            this.reloadPlugin(config)
+              .then(plugin => {
+                resolve(plugin);
+              })
+              .catch(reject);
           } catch (error) {
-            alert(`Failed to load dependencies for ${config.name}: ${error}`);
-            throw `Failed to load dependencies for ${config.name}: ${error}`;
+            //alert(`Failed to load dependencies for ${config.name}: ${error}`);
+            reject(`Failed to load dependencies for ${config.name}: ${error}`);
           }
         })
         .catch(e => {
@@ -1057,10 +1059,9 @@ export class PluginManager {
             resolve(template);
             if (!do_not_load) this.reloadPlugin(template);
           } catch (error) {
-            alert(
+            reject(
               `Failed to install dependencies for ${config.name}: ${error}`
             );
-            throw `Failed to install dependencies for ${config.name}: ${error}`;
           }
         })
         .catch(e => {

--- a/web/src/service-worker.js
+++ b/web/src/service-worker.js
@@ -29,7 +29,7 @@ if (workbox) {
   );
 
   workbox.routing.registerRoute(
-    new RegExp("/.*.(html|css|js)"),
+    new RegExp("/.*\\.(html|css|js)"),
     new workbox.strategies.StaleWhileRevalidate()
   );
 
@@ -82,13 +82,6 @@ if (workbox) {
     if (e.data.action == "skipWaiting") self.skipWaiting();
   });
 
-  self.addEventListener("install", function(event) {
-    event.waitUntil(self.skipWaiting()); // Activate worker immediately
-  });
-
-  self.addEventListener("activate", function(event) {
-    event.waitUntil(self.clients.claim()); // Become available to all pages
-  });
 } else {
   console.log(`Workbox didn't load`);
 }

--- a/web/src/service-worker.js
+++ b/web/src/service-worker.js
@@ -20,12 +20,22 @@ if (workbox) {
 
   workbox.routing.registerRoute(
     new RegExp("/static/.*"),
-    new workbox.strategies.NetworkFirst()
+    new workbox.strategies.StaleWhileRevalidate()
+  );
+
+  workbox.routing.registerRoute(
+    new RegExp("/docs/.*"),
+    new workbox.strategies.StaleWhileRevalidate()
+  );
+
+  workbox.routing.registerRoute(
+    new RegExp("/.*.(html|css|js)"),
+    new workbox.strategies.StaleWhileRevalidate()
   );
 
   workbox.routing.registerRoute(
     new RegExp("(http|https)://lib.imjoy.io/.*"),
-    new workbox.strategies.NetworkFirst()
+    new workbox.strategies.StaleWhileRevalidate()
   );
 
   //communitations
@@ -36,7 +46,7 @@ if (workbox) {
 
   workbox.routing.registerRoute(
     new RegExp("https://static.imjoy.io/.*"),
-    new workbox.strategies.NetworkFirst()
+    new workbox.strategies.StaleWhileRevalidate()
   );
 
   // manifest.imjoy.json etc.
@@ -53,7 +63,7 @@ if (workbox) {
   // badges
   workbox.routing.registerRoute(
     new RegExp("https://img.shields.io/.*"),
-    new workbox.strategies.NetworkFirst()
+    new workbox.strategies.StaleWhileRevalidate()
   );
 
   workbox.routing.registerRoute(
@@ -63,7 +73,7 @@ if (workbox) {
 
   workbox.routing.registerRoute(
     new RegExp("https://zenodo.org/badge/.*"),
-    new workbox.strategies.NetworkFirst()
+    new workbox.strategies.StaleWhileRevalidate()
   );
 
   workbox.routing.setDefaultHandler(new workbox.strategies.NetworkOnly());

--- a/web/src/service-worker.js
+++ b/web/src/service-worker.js
@@ -81,7 +81,6 @@ if (workbox) {
   self.addEventListener("message", e => {
     if (e.data.action == "skipWaiting") self.skipWaiting();
   });
-
 } else {
   console.log(`Workbox didn't load`);
 }


### PR DESCRIPTION
Plugins in web-worker mode failed to load on iOS Safari and complaining `Can't find variable: File`.
Maybe due to a bug in Safari itself? or related to recent changes with service worker, or iframe options?
This is now fixed by check if `File` exists in `_JailedSite.js`.

Use the jailed library from lib.imjoy.io by default, unless `debug_jailed=1` is in the query and the host=localhost or 127.0.0.1.

Support url parameters including `workspace`, `engine`, `token` and `plugin` in imjoy-lite (https://imjoy.io/lite).

Improve error message for iframe plugins.

Use different caching strategies for files on https://imjoy.io