### PR TITLE
restore `cache:` prefix in requirements

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -511,10 +511,10 @@ If the url does not end with `.js`, you need to add `js:` before it, for example
 "requirements": ["js:https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@0.11.2"]
 ```
 
-For offline access, Javascript and CSS files will be automatically cached if added to `requirements`.
-You can also add additional resources (e.g. images, font files) to the offline cache, for example: 
+For **offline access**, Javascript and CSS files will be automatically cached if added to `requirements`.
+You can also add additional resources (e.g. images, font files) to the offline cache by using `cache:` prefix, for example: 
 ```json
-"requirements": ["https://use.fontawesome.com/releases/v5.8.2/webfonts/fa-solid-900.woff2"]
+"requirements": ["cache:https://use.fontawesome.com/releases/v5.8.2/webfonts/fa-solid-900.woff2"]
 ```
 
 Notice that the offline caching process won't trace the dependent resources, you will need to add them as requirements manually in order to be cached.
@@ -526,6 +526,8 @@ Requirements are specified as a list of strings specifying the required python m
 "requirements": ["numpy", "matplotlib"]
 ```
 By default, the packages are loaded from our static hosting on Github (https://github.com/oeway/static.imjoy.io/tree/master/docs/pyodide). Specifically for `scipy`, you need to include an absolute url: `"requirements": ["https://alpha.iodide.app/pyodide-0.10.0/scipy.js"]`.
+
+If you want to import additional js file, you need to use the `js:` prefix before the javascript url.
 
 Please note that `web-python` plugins are based on [pyodide](https://github.com/iodide-project/pyodide/)
 and only a limited number of python modules is currently supported.

--- a/web/src/jailed/_frame.js
+++ b/web/src/jailed/_frame.js
@@ -293,12 +293,7 @@ window.addEventListener("message", function(e) {
   var m = e.data.data;
   if (m.type === "execute") {
     const code = m.code;
-    if (
-      code.type == "requirements" &&
-      (plugin_mode === "iframe" ||
-        plugin_mode === "window" ||
-        plugin_mode === "web-worker")
-    ) {
+    if (code.type == "requirements") {
       if (!Array.isArray(code.requirements)) {
         code.requirements = [code.requirements];
       }

--- a/web/src/jailed/_frame.js
+++ b/web/src/jailed/_frame.js
@@ -62,6 +62,7 @@ async function cacheRequirements(requirements) {
       //remove prefix
       if (req.startsWith("js:")) req = req.slice(3);
       if (req.startsWith("css:")) req = req.slice(4);
+      if (req.startsWith("cache:")) req = req.slice(6);
       if (!req.startsWith("http")) continue;
       await _sendToServiceWorker({
         command: "add",
@@ -104,6 +105,9 @@ var initWebworkerPlugin = function() {
   // initialization without exception, handling this with timeout
   var fallbackTimeout = setTimeout(function() {
     worker.terminate();
+    console.warn(
+      `Plugin ${plugin_name} failed to start as a web-worker, running in an iframe instead.`
+    );
     initIframePlugin();
   }, 2000);
 

--- a/web/src/jailed/_pluginWebIframe.js
+++ b/web/src/jailed/_pluginWebIframe.js
@@ -138,6 +138,8 @@ var execute = async function(code) {
                   code.requirements[i] = code.requirements[i].slice(3);
                 }
                 await importScripts(code.requirements[i]);
+              } else if (code.requirements[i].startsWith("cache:")) {
+                //ignore cache
               } else {
                 console.log(
                   "Unprocessed requirements url: " + code.requirements[i]

--- a/web/src/jailed/_pluginWebPython.js
+++ b/web/src/jailed/_pluginWebPython.js
@@ -174,13 +174,20 @@ var execute = async function(code) {
               link_node.href = code.requirements[i];
               document.head.appendChild(link_node);
             } else if (
-              code.requirements[i].toLowerCase().endsWith(".js") ||
+              // code.requirements[i].toLowerCase().endsWith(".js") ||
               code.requirements[i].startsWith("js:")
             ) {
               if (code.requirements[i].startsWith("js:")) {
                 code.requirements[i] = code.requirements[i].slice(3);
               }
               await importScripts(code.requirements[i]);
+            } else if (code.requirements[i].startsWith("cache:")) {
+              //ignore cache
+            } else if (
+              code.requirements[i].toLowerCase().endsWith(".js") ||
+              code.requirements[i].startsWith("package:")
+            ) {
+              python_packages.push(code.requirements[i]);
             } else if (
               code.requirements[i].startsWith("http:") ||
               code.requirements[i].startsWith("https:")
@@ -188,8 +195,6 @@ var execute = async function(code) {
               console.log(
                 "Unprocessed requirements url: " + code.requirements[i]
               );
-            } else {
-              python_packages.push(code.requirements[i]);
             }
           }
           await pyodide.loadPackage(python_packages);

--- a/web/src/jailed/_pluginWebWorker.js
+++ b/web/src/jailed/_pluginWebWorker.js
@@ -96,6 +96,8 @@ self.connection = {};
                     code.requirements[i] = code.requirements[i].slice(3);
                   }
                   importScripts(code.requirements[i]);
+                } else if (code.requirements[i].startsWith("cache:")) {
+                  //ignore cache
                 } else {
                   console.log(
                     "Unprocessed requirements url: " + code.requirements[i]


### PR DESCRIPTION
The `cache:` prefix was used in `requirements` to allow imjoy to cache assets, it was removed in a previous PR but causing issue with many legacy plugins. This PR restore it.