### PR TITLE
Move Browser File system to a separate plugin

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1239,7 +1239,7 @@ URL of the current plugin engine.
 
 ## Internal plugins
 
-Besides the default ImJoy api, we provide a set of internally supported plugins which can be used directly. These plugins will be loaded only if the plugin is requested by other plugin via `api.getPlugin(...)`.
+Besides the default ImJoy api, we provide a set of internally supported plugins which can be used directly. These plugins will be loaded only if the plugin is requested by another plugin via `api.getPlugin(...)`.
 
 Here is a list of these internal plugins along with their api functions:
 
@@ -1249,14 +1249,7 @@ To use the `BrowserFS` plugin, you need to first call:
 
 `const bfs = await api.getPlugin('BrowserFS')` in Javascript, or `bfs = await api.getPlugin('BrowserFS')` in Python.
 
-The following documentation Assumes we have access to the plugin api via `bfs`.
-
-
-```javascript
-bfs.XXXXX(...)
-```
-
-Access the in-browser filesystem with the [Node JS filesystem API](https://nodejs.org/api/fs.html). More details about the underlying implemetation, see [BrowserFS](https://github.com/jvilk/BrowserFS), the default file system in ImJoy supports the following nodes:
+Then, you can use [Node JS filesystem API](https://nodejs.org/api/fs.html) to access the in-browser filesystem (e.g.: `bfs.readFile('/tmp/temp.txt', 'utf-8')`). For more details about the underlying implemetation, see [BrowserFS](https://github.com/jvilk/BrowserFS), the default file system in ImJoy supports the following nodes:
 
  * `/tmp`: `InMemory`, data is stored in browser memory, cleared when ImJoy is closed.
 
@@ -1267,36 +1260,44 @@ Access the in-browser filesystem with the [Node JS filesystem API](https://nodej
 <!-- tabs:start -->
 #### ** JavaScript **
 ```javascript
-bfs.writeFile('/tmp/temp.txt', 'hello world', function(err, data){
-    if (err) {
-        console.log(err);
-        return
-    }
-    console.log("Successfully Written to File.");
-    bfs.readFile('/tmp/temp.txt', 'utf8', function (err, data) {
-        if (err) {
-            console.log(err);
-            return
-        }
-        console.log('Reald from file', data)
-    });
-});
+async function test_browser_fs(){
+  const bfs = await api.getPlugin('BrowserFS')
+
+  bfs.writeFile('/tmp/temp.txt', 'hello world', function(err, data){
+      if (err) {
+          console.log(err);
+          return
+      }
+      console.log("Successfully Written to File.");
+      bfs.readFile('/tmp/temp.txt', 'utf8', function (err, data) {
+          if (err) {
+              console.log(err);
+              return
+          }
+          console.log('Read from file', data)
+      });
+  });
+}
 ```
 #### ** Python **
 ```python
-def read(err, data=None):
-    if err:
-        print(err)
-        return
 
-    def cb(err, data=None):
-        if err:
-            print(err)
-            return
-        api.log(data)
-    bfs.readFile('/tmp/temp.txt', 'utf8', cb)
+async def test_browser_fs():
+  bfs = await api.getPlugin('BrowserFS')
 
-bfs.writeFile('/tmp/temp.txt', 'hello world', read)
+  def read(err, data=None):
+      if err:
+          print(err)
+          return
+
+      def cb(err, data=None):
+          if err:
+              print(err)
+              return
+          api.log(data)
+      bfs.readFile('/tmp/temp.txt', 'utf8', cb)
+
+  bfs.writeFile('/tmp/temp.txt', 'hello world', read)
 
 ```
 <!-- tabs:end -->

--- a/docs/development.md
+++ b/docs/development.md
@@ -1340,6 +1340,9 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
 ## Change log
 
 ### API changes
+#### api_version: 0.1.7
+ * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const ps = await api.getPlugin('BrowserFS'); const fs = ps.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config into `0.1.6`.
+
 
 #### api_version: 0.1.6
  * added new api functions `api.getPlugins`,  `api.getFileManager`, `api.getEngine`, `api.getEngineFactory`

--- a/docs/development.md
+++ b/docs/development.md
@@ -1341,7 +1341,7 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
 
 ### API changes
 #### api_version: 0.1.7
- * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config into `0.1.6`.
+ * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config to `0.1.6`.
 
 
 #### api_version: 0.1.6

--- a/docs/development.md
+++ b/docs/development.md
@@ -1341,7 +1341,7 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
 
 ### API changes
 #### api_version: 0.1.7
- * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const ps = await api.getPlugin('BrowserFS'); const fs = ps.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config into `0.1.6`.
+ * `api.fs` has been deprecated, the browser file system is moved to a separate plugin `BrowserFS`, to use the file system, you can do `const bfs_plugin = await api.getPlugin('BrowserFS'); const bfs = bfs_plugin.fs;`, now `fs` will be equivalent to `api.fs`. Notice: the data saved with `api.fs` will not be accessible with the new API, to get access the old data, please change `api_version` in the plugin config into `0.1.6`.
 
 
 #### api_version: 0.1.6

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -64,9 +64,9 @@ and image, you will be able to snap an image and perform a prediction.
 ### Digit classification
 Here, we describe how to install and use an ImJoy plugin to perform digit classification
 with TensorFlow.js. This plugin runs directly in the browser. You can train a
-convolution neural network (CNN) to recognise digits. Once the network is trained,
+convolution neural network (CNN) to recognize digits. Once the network is trained,
 you can classify hand drawn numbers. It is based on [tfjs-vis](https://github.com/tensorflow/tfjs-vis)
-- a small library for in browser visualisation for use with TensorFlow.js.
+- a small library for in browser visualization for use with TensorFlow.js.
 
 This plugin can be obtained by installing the plugin `MNIST-CNN` from
 the ImJoy plugin repository. Alternatively, you can also use this

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -237,13 +237,13 @@ class ImJoyPlugin():
 [>>>Full plugin source code](https://gist.github.com/oeway/5edb106eb9360405412bba8ebd2dbeb5/cfbf85f629c3e2258d5be27e295dd438f7f477ff)
 
 ### Get user input and show traininig progress
-You can use [`api.prompt`](https://imjoy.io/docs/#/api?id=apiprompt) function to get user input, for example to specify how many epochs. Similary to [`api.alert`](https://imjoy.io/docs/#/api?id=apialert) function, [`api.showProgress`](https://imjoy.io/docs/#/api?id=apishowprogress) and [`api.showStatus`](https://imjoy.io/docs/#/api?id=apishowstatus) function can be used to show the current training progress.
+You can use [`api.prompt`](https://imjoy.io/docs/#/api?id=apiprompt) function to get user input, for example to specify how many epochs. Similar to [`api.alert`](https://imjoy.io/docs/#/api?id=apialert) function, [`api.showProgress`](https://imjoy.io/docs/#/api?id=apishowprogress) and [`api.showStatus`](https://imjoy.io/docs/#/api?id=apishowstatus) function can be used to show the current training progress.
 
-Importantly, all the api functions are [`async function`](https://imjoy.io/docs/#/api?id=asynchronous-programming), which means the returned value is not the actual results, but a special object called `Promise` or `Future`, we need to explicitly wait for it to get the value. In Python, we can easily use async functions with a built-in libriary called `asyncio` (only available in Python 3) according to the following steps:
+Importantly, all the api functions are [`async function`](https://imjoy.io/docs/#/api?id=asynchronous-programming), which means the returned value is not the actual results, but a special object called `Promise` or `Future`, we need to explicitly wait for it to get the value. In Python, we can easily use async functions with a built-in library called `asyncio` (only available in Python 3) according to the following steps:
 
  1. `import asyncio`
  2. add `async` to any function which you want to call async functions, for example if you want to call `api.prompt` inside `run`, then you need to add `async` before `def run`, i.e.: `async def run(self, ctx):`
- 3. add `await` before the acutal async function you want to call and you can get the actuall value. For example, if you want to get the user input, you need to call `result = await api.prompt('How many epochs do you want to train')`.
+ 3. add `await` before the async function you want to call and you can get the actual value. For example, if you want to get the user input, you need to call `result = await api.prompt('How many epochs do you want to train')`.
 
  **This means you can only use `await` inside a function defined with `async`.**
  **`await` can be ignored if we don't want to wait for the execution or the result, e.g. api.alert('hello'), `await` is optional**
@@ -255,7 +255,7 @@ This is the `run` function if we want to get the epoch number from the user and 
 ```python
     def train(self, epochs):
         ...
-        # pass epochs to model.fit_genenerator function
+        # pass epochs to model.fit_generator function
         model.fit_generator(myGene,steps_per_epoch=300,epochs=epochs,callbacks=[model_checkpoint]
 
     async def run(self, ctx):
@@ -380,7 +380,7 @@ ImJoy provide the [`api.showFileDialog`](https://imjoy.io/docs/#/api?id=apishowf
 [>>>Full plugin source code](https://gist.github.com/oeway/5edb106eb9360405412bba8ebd2dbeb5/44cfd2d1cd6b18774df64de521ebdf80179ca57e)
 
 
-Similarily, we can add a file dialog for prediction.
+Similarly, we can add a file dialog for prediction.
 
 ```python
     async def predict(self):
@@ -404,9 +404,9 @@ Similarily, we can add a file dialog for prediction.
 
 ### Deploy the plugin to Github
 
-Now we have a plugin which allows train Unet models and make prediciton user's own data, we can deploy it to github and share it with others.
+Now we have a plugin which allows train Unet models and make prediction user's own data, we can deploy it to github and share it with others.
 
-The recommended way to do is make a deicated repository and place the plugin file directly into the Github repo.
+The recommended way to do is make a dedicated repository and place the plugin file directly into the Github repo.
 
 As an example, we can login to Github, open https://github.com/zhixuhao/unet and then click the `Fork` button which will create a copy of the unet folder under your own account. For example, we have the copy at https://github.com/imjoy-team/unet.
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -5,8 +5,7 @@ const ajv = new Ajv();
 
 export const INTERNAL_PLUGINS = {
   BrowserFS: {
-    uri:
-      "https://imjoy-team.github.io/core-plugins/BrowserFS.imjoy.html",
+    uri: "https://imjoy-team.github.io/core-plugins/BrowserFS.imjoy.html",
     startup: false,
   },
   "Jupyter-Engine-Manager": {

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -6,7 +6,7 @@ const ajv = new Ajv();
 export const INTERNAL_PLUGINS = {
   BrowserFS: {
     uri:
-      "https://gist.githubusercontent.com/oeway/68acb3e239c40ab1001c8c1bd70dba33/raw/BrowserFS.imjoy.html",
+      "https://imjoy-team.github.io/core-plugins/BrowserFS.imjoy.html",
     startup: false,
   },
   "Jupyter-Engine-Manager": {

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -3,7 +3,7 @@ import { compareVersions } from "./utils.js";
 import Ajv from "ajv";
 const ajv = new Ajv();
 
-export const INTERNEL_PLUGINS = {
+export const INTERNAL_PLUGINS = {
   BrowserFS: {
     uri:
       "https://gist.githubusercontent.com/oeway/68acb3e239c40ab1001c8c1bd70dba33/raw/BrowserFS.imjoy.html",

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -3,6 +3,23 @@ import { compareVersions } from "./utils.js";
 import Ajv from "ajv";
 const ajv = new Ajv();
 
+export const INTERNEL_PLUGINS = {
+  BrowserFS: {
+    uri:
+      "https://gist.githubusercontent.com/oeway/68acb3e239c40ab1001c8c1bd70dba33/raw/BrowserFS.imjoy.html",
+    startup: false,
+  },
+  "Jupyter-Engine-Manager": {
+    uri:
+      "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.imjoy.html",
+    startup: true,
+  },
+  "ImJoy-Engine-Manager": {
+    uri: "https://oeway.github.io/ImJoy-Engine/ImJoy-Engine-Manager.imjoy.html",
+    startup: true,
+  },
+};
+
 ajv.addKeyword("instanceof", {
   compile: function(Class) {
     return function(data) {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1706,7 +1706,7 @@ export default {
               console.log(`Loading internal plugin "${pn}"...`);
               this.pm
                 .reloadPluginRecursively({
-                  uri: this.pm.plugin_names[pn].uri,
+                  uri:INTERNAL_PLUGINS[pn].uri,
                 })
                 .then(() => {
                   console.log(`${pn} loaded.`);
@@ -1753,17 +1753,16 @@ export default {
         this.show_plugin_store = true;
         this.show_plugin_url = false;
         this.downloading_plugin = true;
-        this.pm
-          .addRepository(r)
-          .then(repo => {
-            this.pm.selected_repository = repo;
+        try{
+           this.pm.selected_repository = await this.pm
+          .addRepository(r);
             this.downloading_plugin = false;
-          })
-          .catch(e => {
+        }
+        catch(e){
             this.downloading_plugin = false;
             this.downloading_error =
               "Sorry, the repository URL is invalid: " + e.toString();
-          });
+        }
         this.show_plugin_templates = false;
         this.showAddPluginDialog = true;
       }
@@ -1854,15 +1853,17 @@ export default {
         }
         if (route.query.engine || route.query.e) {
           const engine_url = (route.query.engine || route.query.e).trim();
-          this.em
+          try{
+            this.em
             .addEngine(
               { type: "default", url: engine_url, token: connection_token },
               false
             )
-            .finally(() => {
+          }finally{
               this.em.getEngineByUrl(engine_url).connect();
               this.$forceUpdate();
-            });
+            
+          }
         }
 
         this.plugin_loaded = true;

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1333,6 +1333,9 @@ import {
   compareVersions,
   escapeHTML,
 } from "../utils.js";
+
+import { INTERNEL_PLUGINS } from "../api.js";
+
 import DOMPurify from "dompurify";
 
 import { ImJoy } from "../imjoyLib.js";
@@ -1697,28 +1700,19 @@ export default {
       this.showWelcomeDialog = true;
     } else {
       this.startImJoy(this.$route).then(() => {
-        if (!this.pm.plugin_names["Jupyter-Engine-Manager"]) {
-          console.log("Loading Jupyter-Engine-Manager...");
-          this.pm
-            .reloadPluginRecursively({
-              uri:
-                "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.imjoy.html",
-            })
-            .then(() => {
-              console.log("Jupyter-Engine-Manager loaded.");
-            });
-        }
-
-        if (!this.pm.plugin_names["ImJoy-Engine-Manager"]) {
-          console.log("Loading ImJoy-Engine-Manager...");
-          this.pm
-            .reloadPluginRecursively({
-              uri:
-                "https://oeway.github.io/ImJoy-Engine/ImJoy-Engine-Manager.imjoy.html",
-            })
-            .then(() => {
-              console.log("ImJoy-Engine-Manager loaded.");
-            });
+        for (let pn in INTERNEL_PLUGINS) {
+          if (INTERNEL_PLUGINS[pn].startup) {
+            if (!this.pm.plugin_names[pn]) {
+              console.log(`Loading internal plugin "${pn}"...`);
+              this.pm
+                .reloadPluginRecursively({
+                  uri: this.pm.plugin_names[pn].uri,
+                })
+                .then(() => {
+                  console.log(`${pn} loaded.`);
+                });
+            }
+          }
         }
 
         if (

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1334,7 +1334,7 @@ import {
   escapeHTML,
 } from "../utils.js";
 
-import { INTERNEL_PLUGINS } from "../api.js";
+import { INTERNAL_PLUGINS } from "../api.js";
 
 import DOMPurify from "dompurify";
 
@@ -1700,8 +1700,8 @@ export default {
       this.showWelcomeDialog = true;
     } else {
       this.startImJoy(this.$route).then(() => {
-        for (let pn in INTERNEL_PLUGINS) {
-          if (INTERNEL_PLUGINS[pn].startup) {
+        for (let pn in INTERNAL_PLUGINS) {
+          if (INTERNAL_PLUGINS[pn].startup) {
             if (!this.pm.plugin_names[pn]) {
               console.log(`Loading internal plugin "${pn}"...`);
               this.pm

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1706,7 +1706,7 @@ export default {
               console.log(`Loading internal plugin "${pn}"...`);
               this.pm
                 .reloadPluginRecursively({
-                  uri:INTERNAL_PLUGINS[pn].uri,
+                  uri: INTERNAL_PLUGINS[pn].uri,
                 })
                 .then(() => {
                   console.log(`${pn} loaded.`);
@@ -1753,15 +1753,13 @@ export default {
         this.show_plugin_store = true;
         this.show_plugin_url = false;
         this.downloading_plugin = true;
-        try{
-           this.pm.selected_repository = await this.pm
-          .addRepository(r);
-            this.downloading_plugin = false;
-        }
-        catch(e){
-            this.downloading_plugin = false;
-            this.downloading_error =
-              "Sorry, the repository URL is invalid: " + e.toString();
+        try {
+          this.pm.selected_repository = await this.pm.addRepository(r);
+          this.downloading_plugin = false;
+        } catch (e) {
+          this.downloading_plugin = false;
+          this.downloading_error =
+            "Sorry, the repository URL is invalid: " + e.toString();
         }
         this.show_plugin_templates = false;
         this.showAddPluginDialog = true;
@@ -1853,16 +1851,14 @@ export default {
         }
         if (route.query.engine || route.query.e) {
           const engine_url = (route.query.engine || route.query.e).trim();
-          try{
-            this.em
-            .addEngine(
+          try {
+            this.em.addEngine(
               { type: "default", url: engine_url, token: connection_token },
               false
-            )
-          }finally{
-              this.em.getEngineByUrl(engine_url).connect();
-              this.$forceUpdate();
-            
+            );
+          } finally {
+            this.em.getEngineByUrl(engine_url).connect();
+            this.$forceUpdate();
           }
         }
 

--- a/web/src/engineManager.js
+++ b/web/src/engineManager.js
@@ -133,7 +133,7 @@ export class EngineManager {
 
   destroy() {
     for (let e of this.engines) {
-      e.destroy();
+      this.unregister(e);
     }
   }
 }

--- a/web/src/fileSystemManager.js
+++ b/web/src/fileSystemManager.js
@@ -37,7 +37,7 @@ export class FileSystemManager {
           var convert = function(fn) {
             return function() {
               console.warn(
-                'WARNING: `api.fs` is deprecated since api_version >= 0.1.7, please use `const ps = await api.getPlugin("BrowserFS"); const fs = ps.fs;` instead.'
+                'WARNING: `api.fs` is deprecated since api_version >= 0.1.7, please use `const bfs_plugin = await api.getPlugin("BrowserFS"); const bfs = bfs_plugin.fs;` instead.'
               );
               const args = Array.prototype.slice.call(arguments);
               const newargs = [];

--- a/web/src/fileSystemManager.js
+++ b/web/src/fileSystemManager.js
@@ -6,6 +6,7 @@ const ArrayBufferView = Object.getPrototypeOf(
   Object.getPrototypeOf(new Uint8Array())
 ).constructor;
 
+//TODO: deprecate the file system manager, use the plugin stead
 export class FileSystemManager {
   constructor() {
     this.fs = null;
@@ -35,6 +36,9 @@ export class FileSystemManager {
           //convert arraybuffer to Buffer
           var convert = function(fn) {
             return function() {
+              console.warn(
+                'WARNING: `api.fs` is deprecated since api_version >= 0.1.7, please use `const ps = await api.getPlugin("BrowserFS"); const fs = ps.fs;` instead.'
+              );
               const args = Array.prototype.slice.call(arguments);
               const newargs = [];
               for (let arg of args) {

--- a/web/src/fileSystemManager.js
+++ b/web/src/fileSystemManager.js
@@ -6,7 +6,7 @@ const ArrayBufferView = Object.getPrototypeOf(
   Object.getPrototypeOf(new Uint8Array())
 ).constructor;
 
-//TODO: deprecate the file system manager, use the plugin stead
+//TODO: deprecate the file system manager, use the plugin instead
 export class FileSystemManager {
   constructor() {
     this.fs = null;

--- a/web/src/jailed/_JailedSite.js
+++ b/web/src/jailed/_JailedSite.js
@@ -59,7 +59,15 @@
   JailedSite = function(connection, id, lang) {
     this.id = id;
     this.lang = lang;
-    this._interface = {};
+    this._interface = {
+      // this initial setup will make sure we wait until the api is exported.
+      setup: () => {
+        return new Promise((resolve, reject) => {
+          this._interfaceSetAsRemoteHandler = resolve;
+          this._disconnectHandler = reject;
+        });
+      },
+    };
     this._plugin_interfaces = {};
     this._remote = null;
     this._remoteUpdateHandler = function() {};

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -924,6 +924,8 @@ DynamicPlugin.prototype.terminate = async function(force) {
 };
 
 DynamicPlugin.prototype.on = function(name, handler, fire_if_emitted) {
+  this._callbacks = this._callbacks || {};
+
   if (this._callbacks[name]) {
     this._callbacks[name].push(handler);
   } else {

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -501,12 +501,12 @@ var DynamicPlugin = function(config, _interface, _fs_api, engine, is_proxy) {
   } else {
     this._disconnected = true;
     this._bindInterface(_interface);
-    
-    // use the plugin event functions if it doesn't exist (window plugins has their own event functions) 
-    if(!this._initialInterface.on) this._initialInterface.on = this.on;
-    if(!this._initialInterface.off) this._initialInterface.off = this.off;
-    if(!this._initialInterface.emit) this._initialInterface.emit = this.emit;
-    
+
+    // use the plugin event functions if it doesn't exist (window plugins has their own event functions)
+    if (!this._initialInterface.on) this._initialInterface.on = this.on;
+    if (!this._initialInterface.off) this._initialInterface.off = this.off;
+    if (!this._initialInterface.emit) this._initialInterface.emit = this.emit;
+
     for (let k in _fs_api) this._initialInterface[k] = _fs_api[k];
 
     this._connect();

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -501,6 +501,12 @@ var DynamicPlugin = function(config, _interface, _fs_api, engine, is_proxy) {
   } else {
     this._disconnected = true;
     this._bindInterface(_interface);
+    
+    // use the plugin event functions if it doesn't exist (window plugins has their own event functions) 
+    if(!this._initialInterface.on) this._initialInterface.on = this.on;
+    if(!this._initialInterface.off) this._initialInterface.off = this.off;
+    if(!this._initialInterface.emit) this._initialInterface.emit = this.emit;
+    
     for (let k in _fs_api) this._initialInterface[k] = _fs_api[k];
 
     this._connect();

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -283,43 +283,6 @@ Connection.prototype.disconnect = function() {
 };
 
 /**
- * Plugin constructor, represents a plugin initialized by a script
- * with the given path
- *
- * @param {String} url of a plugin source
- * @param {Object} _interface to provide for the plugin
- */
-var Plugin = function(config, _interface, _fs_api, is_proxy) {
-  this.config = config;
-  this.id = config.id || randId();
-  this._id = config._id;
-  this.name = config.name;
-  this.type = config.type;
-  this.tag = config.tag;
-  this.tags = config.tags;
-  this.type = config.type || "web-worker";
-  this._path = config.url;
-  this._disconnected = true;
-  this.terminating = false;
-  this.initializing = false;
-  this.running = false;
-  this._log_history = [];
-  this.backend = getBackendByType(this.type);
-  this._updateUI =
-    (_interface && _interface.utils && _interface.utils.$forceUpdate) ||
-    function() {};
-  if (is_proxy) {
-    this._disconnected = false;
-  } else {
-    this._disconnected = true;
-    this._bindInterface(_interface);
-    for (let k in _fs_api) this._initialInterface[k] = _fs_api[k];
-    this._connect();
-  }
-  this._updateUI();
-};
-
-/**
  * Platform-dependent implementation of the BasicConnection
  * object, initializes the plugin site and provides the basic
  * messaging-based connection with it

--- a/web/src/joy.js
+++ b/web/src/joy.js
@@ -78,7 +78,7 @@ Joy.normalizeUI = function(ui) {
     normui = ui.trim();
   } else {
     normui = "";
-    console.log("Warining: removing ui string.");
+    console.log("Warning: removing ui string.");
   }
   return normui;
 };

--- a/web/src/plugin-service-worker.js
+++ b/web/src/plugin-service-worker.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-if (workbox) {
+if (typeof workbox !== 'undefined') {
   console.log(`Workbox is loaded (plugin service worker)`);
   /**
    * The workboxSW.precacheAndRoute() method efficiently caches and responds to

--- a/web/src/plugin-service-worker.js
+++ b/web/src/plugin-service-worker.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-if (typeof workbox !== 'undefined') {
+if (typeof workbox !== "undefined") {
   console.log(`Workbox is loaded (plugin service worker)`);
   /**
    * The workboxSW.precacheAndRoute() method efficiently caches and responds to

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -20,7 +20,7 @@ import {
 import { parseComponent } from "./pluginParser.js";
 
 import { DynamicPlugin } from "./jailed/jailed.js";
-import { getBackendByType, INTERNEL_PLUGINS } from "./api.js";
+import { getBackendByType, INTERNAL_PLUGINS } from "./api.js";
 
 import {
   OP_SCHEMA,
@@ -2267,9 +2267,9 @@ export class PluginManager {
     if (target_plugin) {
       return target_plugin.api;
     } else {
-      if (INTERNEL_PLUGINS[plugin_name]) {
+      if (INTERNAL_PLUGINS[plugin_name]) {
         const p = await this.reloadPluginRecursively({
-          uri: INTERNEL_PLUGINS[plugin_name].uri,
+          uri: INTERNAL_PLUGINS[plugin_name].uri,
         }).then(() => {
           console.log("BrowserFS loaded.");
         });

--- a/web/src/plugins/iframeTemplate.imjoy.html
+++ b/web/src/plugins/iframeTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/nativePythonTemplate.imjoy.html
+++ b/web/src/plugins/nativePythonTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webPythonTemplate.imjoy.html
+++ b/web/src/plugins/webPythonTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webPythonWindowTemplate.imjoy.html
+++ b/web/src/plugins/webPythonWindowTemplate.imjoy.html
@@ -15,7 +15,7 @@
   "outputs": null,
   "flags": [],
   "icon": "extension",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/webWorkerTemplate.imjoy.html
+++ b/web/src/plugins/webWorkerTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/src/plugins/windowTemplate.imjoy.html
+++ b/web/src/plugins/windowTemplate.imjoy.html
@@ -14,7 +14,7 @@
   "icon": "extension",
   "inputs": null,
   "outputs": null,
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "env": "",
   "permissions": [],
   "requirements": [],

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -148,7 +148,7 @@ describe("ImJoy.vue", async () => {
     plugin.terminate();
   }).timeout(20000);
 
-  it("should write and read file", done => {
+  it("should write and read file with api.fs", done => {
     fsm.init().then(fs => {
       var c = "New File Contents";
       fs.writeFile("/tmp/test.txt", c, function(err) {
@@ -282,7 +282,7 @@ describe("ImJoy.vue", async () => {
       expect(await plugin1.api.test_get_attachment()).to.be.true;
     });
 
-    it("should read and write with fs", async () => {
+    it("should read and write with BrowserFS plugin", async () => {
       expect(await plugin1.api.test_fs()).to.be.true;
     });
   });

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -143,7 +143,7 @@ class ImJoyPlugin {
     return true
   }
 
-  test_fs() {
+  async test_fs() {
     const fp = await api.getPlugin('BrowserFS')
     const fs = fp.fs;
     return new Promise((resolve, reject)=>{

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -9,7 +9,7 @@
   "tags": [],
   "ui": "",
   "version": "0.1.0",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "url": "",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",
@@ -141,7 +141,8 @@ class ImJoyPlugin {
   }
 
   test_fs() {
-    const fs = api.fs
+    const fp = await api.getPlugin('BrowserFS')
+    const fs = fp.fs;
     return new Promise((resolve, reject)=>{
         function generate_random_data(size){
             var chars = 'abcdefghijklmnopqrstuvwxyz'.split('');
@@ -154,8 +155,7 @@ class ImJoyPlugin {
 
             return random_data.join('');
         }
-
-        const fs = api.fs
+  
         fs.writeFile('/tmp/test.txt', generate_random_data(100000), function(err){
         if (err){
             console.error(err);

--- a/web/tests/testWebWorkerPlugin2.imjoy.html
+++ b/web/tests/testWebWorkerPlugin2.imjoy.html
@@ -9,7 +9,7 @@
   "tags": [],
   "ui": "",
   "version": "0.1.0",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "url": "",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",

--- a/web/tests/testWindowPlugin1.imjoy.html
+++ b/web/tests/testWindowPlugin1.imjoy.html
@@ -9,7 +9,7 @@
   "tags": [],
   "ui": "",
   "version": "0.1.0",
-  "api_version": "0.1.6",
+  "api_version": "0.1.7",
   "description": "[TODO: describe this plugin with one sentence.]",
   "icon": "extension",
   "inputs": null,


### PR DESCRIPTION
Currently the browser file system is available via `api.fs`, and it appears a bit bulky, it's better to move to a separate plugin.

This PR also groups all the internal plugins to manage.