### PR TITLE
Custom encoding/decoding for RPC

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1341,6 +1341,38 @@ Name of the current workspace.
 
 URL of the current plugin engine.
 
+## Experimental APIs
+
+### `_rpcEncode` and `_rpcDecode`
+Remote Procedure Calls (RPC) in ImJoy allows isolated plugins communcate via functions calls and transmit data by passing augments, however, not all the data types are supported. It only support primitive types (number, string, bytes) and basic array/list, object/dictionary. To extend the supported types, one can provide custom encoding and decoding functions (as the plugin API).
+
+
+```javascript
+class ImJoyPlugin {
+  async setup() {
+  }
+
+  async run(ctx) {
+
+  }
+
+  _rpcEncode(d){
+    if(d === 998 ){
+      return {__rpc_dtype__: 'a_special_number'}
+    }
+    else
+      return d
+  }
+
+  _rpcDecode(d){
+    if(d.__rpc_dtype__ === 'a_special_number'){
+      return 998
+    }
+  }
+}
+```
+NOTE: this only works inside plugins with `window`, `iframe`, `web-worker`, it not yet ready for e.g. `native-python`.
+
 
 ## Sanitized HTML and CSS
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1325,8 +1325,7 @@ Currently supported functions for **all plugins** are:
  * `api.utils.$forceUpdate()`: refreshes the GUI manually.
  * `api.utils.openUrl(url)`: opens an `url` in a new browser tab.
  * `api.utils.sleep(duration)`: sleeps for the indicated `duration` in seconds. Note for Python plugins, use `time.sleep` instead.)
- * `api.utils.assert(expression, error_message)`: assert an expression, typically used in a test to make sure a certain condition is met. E.g: `api.utils.assert(v === 98)`
-
+ 
 Currently supported functions for **Python plugins** are:
  * `api.utils.kill(subprocess)`: kills a `subprocess` in python.
  * `api.utils.ndarray(numpy_array)`: wrapps a ndarray `numpy_array` according to the ImJoy ndarray format.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1371,7 +1371,7 @@ class ImJoyPlugin {
   }
 }
 ```
-NOTE: this only works inside plugins with `window`, `iframe`, `web-worker`, it not yet ready for e.g. `native-python`.
+NOTE: this only works inside plugins with `window`, `iframe`, `web-worker`, it doesn't not work directly for e.g. `native-python` unless the coresponding plugin engine support it.
 
 
 ## Sanitized HTML and CSS

--- a/docs/development.md
+++ b/docs/development.md
@@ -1340,7 +1340,10 @@ Follow these steps, and you will be able to run ImJoy server and the plugin engi
 ## Change log
 
 ### API changes
-
+#### api_version: 0.1.7
+ * added `_rpcEncode` and `_rpcDecode` to support custom encoding and decoding
+ * remove `api.utils.assert` because the async version is misleading
+ 
 #### api_version: 0.1.6
  * added new api functions `api.getPlugins`,  `api.getFileManager`, `api.getEngine`, `api.getEngineFactory`
  * `api.getFileUrl` is deprecated, call `file_manager = await api.getFilemanager('http://...');` and then access them with `file_manager.getFileUrl`.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1463,6 +1463,7 @@ export default {
         $forceUpdate: this.$forceUpdate,
         openUrl: this.openUrl,
         sleep: this.sleep,
+        //TODO: deprecate assert in the next version
         assert: assert,
       },
     };

--- a/web/src/jailed/_JailedSite.js
+++ b/web/src/jailed/_JailedSite.js
@@ -555,8 +555,11 @@
         if (typeof this._interface._rpcEncode === "function") {
           const encoded_obj = this._interface._rpcEncode(v);
           if (encoded_obj && encoded_obj.__rpc_dtype__) {
-            bObject[k] = {__jailed_type__: 'custom_encoding', __value__: encoded_obj};
-            continue
+            bObject[k] = {
+              __jailed_type__: "custom_encoding",
+              __value__: encoded_obj,
+            };
+            continue;
           }
           // if the returned object does not contain __jailed_type__, assuming the object has been transformed
           else {
@@ -739,8 +742,7 @@
         if (typeof this._interface._rpcDecode === "function") {
           const decodedObj = this._interface._rpcDecode(aObject.__value__);
           bObject = decodedObj;
-        }
-        else{
+        } else {
           bObject = aObject;
         }
       } else if (aObject.__jailed_type__ === "callback") {

--- a/web/tests/ImJoy.spec.js
+++ b/web/tests/ImJoy.spec.js
@@ -285,5 +285,9 @@ describe("ImJoy.vue", async () => {
     it("should read and write with fs", async () => {
       expect(await plugin1.api.test_fs()).to.be.true;
     });
+
+    it("should work with custom encoding and decoding", async () => {
+      expect(await plugin1.api.test_encoding_decoding()).to.be.true;
+    });
   });
 });

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -33,6 +33,13 @@ class ImJoyPlugin {
     console.log('running in the plugin.')
   }
 
+  _rpcDecode(d){
+    if(d.__rpc_dtype__ === '10x-number'){
+      return d.value / 10
+    }
+    return d
+  }
+
   async test_register() {
     await api.register({
          "name": "LUT",

--- a/web/tests/testWebWorkerPlugin1.imjoy.html
+++ b/web/tests/testWebWorkerPlugin1.imjoy.html
@@ -25,6 +25,17 @@
 </config>
 
 <script lang="javascript">
+
+function assert(condition, message) {
+  if (!condition) {
+    message = message || "Assertion failed";
+    if (typeof Error !== "undefined") {
+      throw new Error(message);
+    }
+    throw message; // Fallback
+  }
+}
+
 class ImJoyPlugin {
   async setup() {
   }
@@ -34,10 +45,17 @@ class ImJoyPlugin {
   }
 
   _rpcDecode(d){
-    if(d.__rpc_dtype__ === '10x-number'){
-      return d.value / 10
+    if(d.__rpc_dtype__ === 'my_special_number'){
+      return 'adsfwe02303'
     }
     return d
+  }
+
+  async test_encoding_decoding() {
+    const p = await api.getPlugin('Test Web Worker Plugin 2')
+    const ret = await p.square(99)
+    assert(ret === 'adsfwe02303', `The anwser should have been encoded into "adsfwe02303" by _rpcDecode(), not ${ret}`)
+    return true
   }
 
   async test_register() {
@@ -119,34 +137,34 @@ class ImJoyPlugin {
 
   async test_run() {
     const ret = await api.run('Test Web Worker Plugin 2', 199)
-    api.utils.assert(ret === 199)
+    assert(ret === 199)
     return true
   }
 
   async test_call() {
     const ret = await api.call('Test Web Worker Plugin 2', 'square', 199)
-    api.utils.assert(ret === 199*199)
+    assert(ret === 199*199)
     return true
   }
 
   async test_get_plugin() {
     const p = await api.getPlugin('Test Web Worker Plugin 2')
     const ret = await p.square(199)
-    api.utils.assert(ret === 199*199)
+    assert(ret === 199*199)
     return true
   }
 
   async test_config() {
     await api.setConfig('some_secret', 123)
-    api.utils.assert(await api.getConfig('some_secret') === '123')
+    assert(await api.getConfig('some_secret') === '123')
     await api.setConfig('some_secret', 'magic word')
-    api.utils.assert(await api.getConfig('some_secret') === 'magic word')
+    assert(await api.getConfig('some_secret') === 'magic word')
     return true
   }
 
   async test_get_attachment() {
     const t = await api.getAttachment('some_text_data')
-    api.utils.assert(t.includes('hello world!'))
+    assert(t.includes('hello world!'))
     return true
   }
 

--- a/web/tests/testWebWorkerPlugin2.imjoy.html
+++ b/web/tests/testWebWorkerPlugin2.imjoy.html
@@ -36,8 +36,8 @@ class ImJoyPlugin {
   }
 
   _rpcEncode(d){
-    if(typeof d === 'number'){
-      return {__rpc_dtype__: '10x-number', value: d*10}
+    if(d === 99*99){
+      return {__rpc_dtype__: 'my_special_number'}
     }
     return d
   }

--- a/web/tests/testWebWorkerPlugin2.imjoy.html
+++ b/web/tests/testWebWorkerPlugin2.imjoy.html
@@ -34,6 +34,13 @@ class ImJoyPlugin {
   async square(arg) {
     return arg*arg
   }
+
+  _rpcEncode(d){
+    if(typeof d === 'number'){
+      return {__rpc_dtype__: '10x-number', value: d*10}
+    }
+    return d
+  }
 }
 
 api.export(new ImJoyPlugin())


### PR DESCRIPTION
Remote Procedure Calls (RPC) in ImJoy allows isolated plugins communcate via functions calls and transmit data by passing augments, however, not all the data types are supported. It only support primitive types (number, string, bytes) and basic array/list, object/dictionary. To extend the supported types, one can provide custom encoding and decoding functions (as the plugin API).


```javascript
class ImJoyPlugin {
  async setup() {
  }

  async run(ctx) {

  }

  _rpcEncode(d){
    if(d === 998 ){
      return {__rpc_dtype__: 'a_special_number'}
    }
    else
      return d
  }

  _rpcDecode(d){
    if(d.__rpc_dtype__ === 'a_special_number'){
      return 998
    }
  }
}
```
NOTE: this only works inside plugins with `window`, `iframe`, `web-worker`, it doesn't not work directly for e.g. `native-python` unless the coresponding plugin engine support it.


This PR also removes `api.utils.assert` which is confusing because it only works if we add `await`.