### PR TITLE
Support plugin file preview

### DIFF
--- a/web/public/static/js/imjoy-preview.js
+++ b/web/public/static/js/imjoy-preview.js
@@ -1,0 +1,8 @@
+if(window && window.location && window.location.protocol === 'file:'){
+    const preview = window.open("https://imjoy.io/#/preview");
+    window.addEventListener("message", function(ev) {
+        if (ev.data.type === "imjoy-app-ready") {
+            preview.postMessage({ type: "load-imjoy-plugin", code: document.body.innerHTML }, "*");
+        }
+    });
+}

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -1042,273 +1042,7 @@
         <about></about>
       </md-dialog-content>
     </md-dialog>
-
-    <md-dialog
-      class="plugin-dialog"
-      :md-active.sync="showAddPluginDialog"
-      :md-click-outside-to-close="true"
-    >
-      <md-dialog-title
-        >{{
-          plugin4install ? "Plugin Installation" : "ImJoy Plugin Management"
-        }}
-        <md-button
-          class="md-accent"
-          style="position:absolute; top:8px; right:5px;"
-          @click="
-            showAddPluginDialog = false;
-            clearPluginUrl();
-          "
-          ><md-icon>clear</md-icon></md-button
-        ></md-dialog-title
-      >
-      <md-dialog-content>
-        <template v-if="show_plugin_templates">
-          <md-menu>
-            <md-button class="md-primary md-raised" md-menu-trigger>
-              <md-icon>add</md-icon>Create a new plugin
-              <md-tooltip>Create a new plugin</md-tooltip>
-            </md-button>
-            <md-menu-content>
-              <md-menu-item
-                @click="
-                  newPlugin(template.code);
-                  showAddPluginDialog = false;
-                "
-                v-for="template in plugin_templates"
-                :key="template.name"
-              >
-                <md-icon>{{ template.icon }}</md-icon
-                >{{ template.name }}
-              </md-menu-item>
-            </md-menu-content>
-          </md-menu>
-          <br />
-          <br />
-        </template>
-
-        <!-- <md-switch v-if="pm.installed_plugins.length>0 && !plugin4install && !downloading_error && !downloading_plugin" v-model="show_installed_plugins">Show Installed Plugins</md-switch> -->
-        <!-- <md-card v-if="show_installed_plugins">
-        <md-card-header>
-          <div class="md-title">Installed Plugins</div>
-        </md-card-header>
-        <md-card-content>
-          <plugin-list name="Installed Plugins" description="" v-if="pm" :plugin-manager="pm" @message="showMessage" :plugins="pm.installed_plugins" :workspace="pm.selected_workspace"></plugin-list>
-        </md-card-content>
-      </md-card> -->
-        <md-card v-if="show_plugin_url">
-          <md-card-header>
-            <div class="md-title">Install from URL</div>
-            <md-toolbar md-elevation="0">
-              <md-field md-clearable class="md-toolbar-section-start">
-                <md-icon>cloud_download</md-icon>
-                <md-input
-                  placeholder="Please paste the URL here and press enter."
-                  type="text"
-                  v-model="plugin_url"
-                  @keyup.enter="
-                    tag4install = '';
-                    getPlugin4Install(plugin_url);
-                  "
-                  name="plugin_url"
-                ></md-input>
-                <md-tooltip>Press `Enter` to get the plugin</md-tooltip>
-              </md-field>
-            </md-toolbar>
-          </md-card-header>
-        </md-card>
-        <div
-          v-if="downloading_plugin && !plugin4install"
-          class="md-toolbar-section-center"
-        >
-          <div style="padding-right: 30px;" class="loading loading-lg"></div>
-        </div>
-        <h2 v-if="downloading_error">&nbsp;&nbsp;{{ downloading_error }}</h2>
-        <md-card v-if="plugin4install">
-          <md-card-media
-            v-if="
-              plugin4install.cover && typeof plugin4install.cover === 'string'
-            "
-            md-ratio="16:9"
-          >
-            <img :src="plugin4install.cover" alt="plugin-cover" />
-          </md-card-media>
-          <div class="carousel" v-else-if="plugin4install.cover">
-            <!-- carousel locator -->
-            <input
-              v-once
-              class="carousel-locator"
-              v-for="(c, k) in plugin4install.cover"
-              :key="k"
-              :id="'slide-' + k"
-              type="radio"
-              name="carousel-radio"
-              hidden=""
-              :checked="k === 1"
-            />
-            <!-- carousel container -->
-            <div class="carousel-container">
-              <!-- carousel item -->
-              <figure
-                class="carousel-item"
-                v-for="(c, k) in plugin4install.cover"
-                :key="k"
-              >
-                <img
-                  class="img-responsive rounded"
-                  :src="c"
-                  alt="plugin cover"
-                />
-              </figure>
-            </div>
-            <!-- carousel navigation -->
-            <div class="carousel-nav">
-              <label
-                class="nav-item text-hide c-hand"
-                v-for="(c, k) in plugin4install.cover"
-                :key="k"
-                :for="'slide-' + k"
-                >{{ k }}</label
-              >
-            </div>
-          </div>
-          <md-card-header>
-            <md-toolbar md-elevation="0">
-              <div>
-                <h2>
-                  <md-icon v-if="plugin4install.icon">{{
-                    plugin4install.icon
-                  }}</md-icon
-                  ><md-icon v-else>extension</md-icon>
-                  {{ plugin4install.name + " " + plugin4install.badges }}
-                </h2>
-              </div>
-              <div
-                v-if="installing || !plugin_loaded"
-                class="md-toolbar-section-end"
-              >
-                <div
-                  style="padding-right: 30px;"
-                  class="loading loading-lg"
-                ></div>
-              </div>
-              <div v-else-if="tag4install" class="md-toolbar-section-end">
-                <md-button
-                  class="md-button md-primary"
-                  @click="installPlugin(plugin4install, tag4install)"
-                >
-                  <md-icon>cloud_download</md-icon
-                  >{{ plugin4install._installation_text || "Install" }}
-                  <md-tooltip
-                    >Install {{ plugin4install.name }} (tag=`{{
-                      tag4install
-                    }}`)</md-tooltip
-                  >
-                </md-button>
-              </div>
-              <div v-else class="md-toolbar-section-end">
-                <md-menu
-                  v-if="plugin4install.tags && plugin4install.tags.length > 0"
-                >
-                  <md-button class="md-button md-primary" md-menu-trigger>
-                    <md-icon>cloud_download</md-icon
-                    >{{ plugin4install._installation_text || "Install" }}
-                    <md-tooltip
-                      >Choose a tag to install
-                      {{ plugin4install.name }}</md-tooltip
-                    >
-                  </md-button>
-                  <md-menu-content>
-                    <md-menu-item
-                      v-for="tag in plugin4install.tags"
-                      :key="tag"
-                      @click="installPlugin(plugin4install, tag)"
-                    >
-                      <md-icon>cloud_download</md-icon>{{ tag }}
-                    </md-menu-item>
-                  </md-menu-content>
-                </md-menu>
-                <md-button
-                  v-else
-                  class="md-button md-primary"
-                  @click="installPlugin(plugin4install)"
-                >
-                  <md-icon>cloud_download</md-icon
-                  >{{ plugin4install._installation_text || "Install" }}
-                </md-button>
-              </div>
-            </md-toolbar>
-          </md-card-header>
-          <md-card-content>
-            <p>Version: {{ plugin4install.version }}</p>
-            <p>{{ plugin4install.description }}</p>
-            <md-chip
-              v-for="tag in plugin4install.tags"
-              @click="tag4install = tag"
-              :class="tag4install === tag ? 'md-primary' : ''"
-              :key="tag"
-              >{{ tag }}</md-chip
-            >
-            <!-- <md-button class="md-button md-primary" @click="showCode(plugin4install)">
-            <md-icon>code</md-icon>Code
-          </md-button> -->
-            <br />
-            <md-switch v-if="plugin4install.code" v-model="show_plugin_source"
-              >Show plugin source code</md-switch
-            >
-            <p>
-              This plugin is <strong>NOT</strong> provided by ImJoy.io. Please
-              make sure the plugin is provided by a trusted source, otherwise it
-              may <strong>harm</strong> your computer.
-            </p>
-            <plugin-editor
-              v-if="show_plugin_source"
-              class="code-editor"
-              v-model="plugin4install.code"
-              :title="plugin4install.name"
-            ></plugin-editor>
-          </md-card-content>
-        </md-card>
-        <md-card v-show="show_plugin_store">
-          <md-card-header>
-            <div class="md-title">Install from the plugin repository</div>
-            <md-chips
-              @md-insert="pm.addRepository($event)"
-              @md-delete="pm.removeRepository(getRepository($event))"
-              class="md-primary shake-on-error"
-              v-model="pm.repository_names"
-              md-placeholder="Add a repository url (e.g. GITHUB REPO) and press enter."
-            >
-              <template slot="md-chip" slot-scope="{ chip }">
-                <strong
-                  class="md-primary"
-                  v-if="
-                    pm.selected_repository &&
-                      chip === pm.selected_repository.name
-                  "
-                  >{{ chip }}</strong
-                >
-                <div v-else @click="selectRepository(chip)">{{ chip }}</div>
-              </template>
-              <div class="md-helper-text" v-if="pm.selected_repository">
-                {{ pm.selected_repository.name }}:
-                {{ pm.selected_repository.description }}
-              </div>
-            </md-chips>
-          </md-card-header>
-          <md-card-content>
-            <plugin-list
-              @message="showMessage"
-              v-if="pm"
-              :plugin-manager="pm"
-              :init-search="init_plugin_search"
-              :plugins="pm.available_plugins"
-              :workspace="pm.selected_workspace"
-            ></plugin-list>
-          </md-card-content>
-        </md-card>
-      </md-dialog-content>
-    </md-dialog>
+    <preview ref="preview" :plugin-manager="pm" :engine-manager="em"></preview>
   </div>
 </template>
 
@@ -1317,10 +1051,6 @@
 
 import { saveAs } from "file-saver";
 import axios from "axios";
-import WEB_WORKER_PLUGIN_TEMPLATE from "../plugins/webWorkerTemplate.imjoy.html";
-import NATIVE_PYTHON_PLUGIN_TEMPLATE from "../plugins/nativePythonTemplate.imjoy.html";
-import WEB_PYTHON_PLUGIN_TEMPLATE from "../plugins/webPythonTemplate.imjoy.html";
-import WINDOW_PLUGIN_TEMPLATE from "../plugins/windowTemplate.imjoy.html";
 import JUPYTER_NOTEBOOK_TEMPLATE from "../plugins/jupyterNotebookTemplate.imjoy.html";
 
 import { version } from "../../package.json";
@@ -1362,22 +1092,6 @@ export default {
       showPluginDialog: false,
       showSettingsDialog: false,
       showAboutDialog: false,
-      showAddPluginDialog: false,
-      permission_message: "No permission message.",
-      share_url_message: "No url",
-      resolve_permission: null,
-      reject_permission: null,
-      plugin_url: null,
-      downloading_plugin: false,
-      downloading_error: "",
-      plugin4install: null,
-      tag4install: "",
-      show_plugin_source: false,
-      init_plugin_search: null,
-      show_plugin_templates: true,
-      show_plugin_store: true,
-      show_plugin_url: true,
-      show_installed_plugins: false,
       progress: 0,
       status_text: "",
       showWorkspaceDialog: false,
@@ -1504,30 +1218,7 @@ export default {
     this.IMJOY_PLUGIN = {
       _id: "IMJOY_APP",
     };
-    this.plugin_templates = [
-      {
-        name: "Default template",
-        code: WEB_WORKER_PLUGIN_TEMPLATE,
-        icon: "code",
-      },
-      {
-        name: "Web Worker (JS)",
-        code: WEB_WORKER_PLUGIN_TEMPLATE,
-        icon: "swap_horiz",
-      },
-      {
-        name: "Window (HTML/CSS/JS)",
-        code: WINDOW_PLUGIN_TEMPLATE,
-        icon: "picture_in_picture",
-      },
-      {
-        name: "Native Python",
-        code: NATIVE_PYTHON_PLUGIN_TEMPLATE,
-        icon: "🚀",
-      },
-      // {name: "Iframe(Javascript)", code: IFRAME_PLUGIN_TEMPLATE},
-      { name: "Web Python", code: WEB_PYTHON_PLUGIN_TEMPLATE, icon: "🐍" },
-    ];
+
     this.workflow_joy_config = {
       expanded: true,
       name: "Workflow",
@@ -1722,7 +1413,7 @@ export default {
         }
 
         if (
-          !this.showAddPluginDialog &&
+          !this.$refs.preview.showAddPluginDialog &&
           (!this.pm.plugins || Object.keys(this.pm.plugins) <= 0)
         ) {
           this.pm
@@ -1754,34 +1445,44 @@ export default {
 
       const r = (route.query.repo || route.query.r || "").trim();
       if (r) {
-        this.plugin_url = null;
-        this.init_plugin_search = null;
-        this.show_plugin_store = true;
-        this.show_plugin_url = false;
-        this.downloading_plugin = true;
         this.pm
           .addRepository(r)
           .then(repo => {
             this.pm.selected_repository = repo;
-            this.downloading_plugin = false;
+            this.event_bus.emit("update_preview", {
+              downloading_plugin: false,
+            });
           })
           .catch(e => {
-            this.downloading_plugin = false;
-            this.downloading_error =
-              "Sorry, the repository URL is invalid: " + e.toString();
+            this.event_bus.emit("update_preview", {
+              downloading_plugin: false,
+              downloading_error:
+                "Sorry, the repository URL is invalid: " + e.toString(),
+            });
           });
-        this.show_plugin_templates = false;
-        this.showAddPluginDialog = true;
+        this.event_bus.emit("update_preview", {
+          plugin_url: null,
+          init_plugin_search: null,
+          show_plugin_store: true,
+          show_plugin_url: false,
+          downloading_plugin: true,
+          show_plugin_templates: false,
+          showAddPluginDialog: true,
+        });
       }
 
       const p = (route.query.plugin || route.query.p || "").trim();
       let plugin_config = null;
       if (p) {
         if (p.match(url_regex) || (p.includes("/") && p.includes(":"))) {
-          this.plugin_url = p;
-          this.init_plugin_search = null;
-          this.show_plugin_store = false;
-          this.show_plugin_url = false;
+          this.event_bus.emit("update_preview", {
+            plugin_url: p,
+            init_plugin_search: null,
+            show_plugin_store: false,
+            show_plugin_url: false,
+            show_plugin_templates: false,
+            showAddPluginDialog: true,
+          });
           try {
             plugin_config = await this.getPlugin4Install(p);
             //check if the same plugin is already installed
@@ -1791,8 +1492,10 @@ export default {
               plugin_config.version !==
                 this.pm.plugin_names[plugin_config.name].config.version
             ) {
-              this.show_plugin_templates = false;
-              this.showAddPluginDialog = true;
+              this.event_bus.emit("update_preview", {
+                show_plugin_templates: false,
+                showAddPluginDialog: true,
+              });
             } else {
               this.showMessage(
                 `Plugin "${plugin_config.name}" is already installed.`
@@ -1803,12 +1506,14 @@ export default {
             await this.showAlert(null, e);
           }
         } else {
-          this.plugin_url = null;
-          this.init_plugin_search = p;
-          this.show_plugin_store = true;
-          this.show_plugin_url = false;
-          this.show_plugin_templates = false;
-          this.showAddPluginDialog = true;
+          this.event_bus.emit("update_preview", {
+            plugin_url: null,
+            init_plugin_search: p,
+            show_plugin_store: true,
+            show_plugin_url: false,
+            show_plugin_templates: false,
+            showAddPluginDialog: true,
+          });
         }
       } else {
         if (route.query.workflow) {
@@ -1882,7 +1587,7 @@ export default {
             const ps = this.pm.installed_plugins.filter(p => {
               return p.name === pname;
             });
-            if (!this.showAddPluginDialog && ps.length <= 0) {
+            if (!this.$refs.preview.showAddPluginDialog && ps.length <= 0) {
               alert(`Plugin "${pname}" cannot be started, please install it.`);
             } else {
               const data = _clone(route.query);
@@ -1904,7 +1609,7 @@ export default {
               }
               //load data
               if (
-                !this.showAddPluginDialog &&
+                !this.$refs.preview.showAddPluginDialog &&
                 (this.pm.registered.windows[pname] ||
                   pname.startsWith("imjoy/"))
               ) {
@@ -2244,9 +1949,11 @@ export default {
       }
     },
     async getPlugin4Install(plugin_url) {
-      this.plugin4install = null;
-      this.downloading_error = "";
-      this.downloading_plugin = true;
+      this.event_bus.emit("update_preview", {
+        plugin4install: null,
+        downloading_error: "",
+        downloading_plugin: true,
+      });
       try {
         const config = await this.pm.getPluginFromUrl(plugin_url);
 
@@ -2269,26 +1976,33 @@ export default {
             config._installation_text = "Downgrade";
           }
         }
-        this.plugin4install = config;
-        this.tag4install = config.tag;
-        this.downloading_plugin = false;
+        this.event_bus.emit("update_preview", {
+          plugin4install: config,
+          tag4install: config.tag,
+          downloading_plugin: false,
+        });
         return config;
       } catch (e) {
-        this.downloading_plugin = false;
-        this.downloading_error = `Failed to fetch plugin, error: ${e}`;
-        this.showMessage(this.downloading_error);
+        this.event_bus.emit("update_preview", {
+          downloading_error: `Failed to fetch plugin, error: ${e}`,
+          downloading_plugin: false,
+        });
+        this.showMessage(`Failed to fetch plugin, error: ${e}`);
         throw e;
       }
     },
     showPluginManagement() {
-      this.plugin4install = null;
-      this.downloading_error = "";
-      this.downloading_plugin = false;
-      this.init_plugin_search = "";
-      this.show_plugin_templates = true;
-      this.show_plugin_store = true;
-      this.show_plugin_url = true;
-      this.showAddPluginDialog = true;
+      this.event_bus.emit("update_preview", {
+        plugin4install: null,
+        downloading_error: "",
+        downloading_plugin: false,
+        init_plugin_search: "",
+        show_plugin_templates: true,
+        show_plugin_store: true,
+        show_plugin_url: true,
+        showAddPluginDialog: true,
+      });
+
       //select ImJoy repo as default
       for (let repo of this.pm.repository_list) {
         if (repo.name === this.pm.default_repository_list[0].name) {
@@ -2405,17 +2119,6 @@ export default {
           throw e;
         });
     },
-    processPermission(allow) {
-      if (allow && this.resolve_permission) {
-        this.resolve_permission();
-        this.resolve_permission = null;
-      } else if (this.reject_permission) {
-        this.reject_permission("Permission Denied!");
-        this.reject_permission = null;
-      } else {
-        console.error("permission handler not found.");
-      }
-    },
     showDoc(pid) {
       const plugin = this.pm.plugins[pid];
       const pconfig = plugin.config;
@@ -2433,13 +2136,6 @@ export default {
         },
       };
       this.createWindow(w);
-    },
-    clearPluginUrl() {
-      const query = Object.assign({}, this.$route.query);
-      // delete query.p;
-      // delete query.plugin;
-      delete query.upgrade;
-      this.$router.replace({ query });
     },
     sharePlugin(pid) {
       const plugin = this.pm.plugins[pid];
@@ -2468,19 +2164,6 @@ export default {
       });
       saveAs(file, filename);
     },
-    installPlugin(plugin4install, tag4install) {
-      this.installing = true;
-      this.pm
-        .installPlugin(plugin4install, tag4install)
-        .then(template => {
-          this.showAddPluginDialog = false;
-          this.clearPluginUrl(template);
-          this.$forceUpdate();
-        })
-        .finally(() => {
-          this.installing = false;
-        });
-    },
     updatePlugin(pid) {
       const plugin = this.pm.plugins[pid];
       const pconfig = plugin.config;
@@ -2490,11 +2173,6 @@ export default {
           .then(() => {
             //clear message
             this.showStatus(null, " ");
-            this.show_plugin_templates = false;
-            this.showAddPluginDialog = true;
-            this.init_plugin_search = null;
-            this.show_plugin_store = false;
-            this.show_plugin_url = false;
           })
           .catch(e => {
             this.showMessage(`Failed to fetch plugin source code (${e}).`);
@@ -3126,24 +2804,11 @@ export default {
   height: 100%;
 }
 
-.plugin-dialog {
-  width: 80%;
-  max-width: 800px;
-  max-height: 90%;
-}
-
 @media screen and (max-width: 400px) {
   .md-dialog {
     width: 100% !important;
     max-height: 100%;
     max-width: 100%;
-  }
-}
-
-@media screen and (max-width: 700px) {
-  .plugin-dialog {
-    width: 100% !important;
-    max-width: 100% !important;
   }
 }
 
@@ -3177,12 +2842,6 @@ export default {
 
 #api-snackbar {
   z-index: 14 !important;
-}
-
-@media screen and (max-height: 900px) {
-  .plugin-dialog {
-    max-height: 100%;
-  }
 }
 
 @media screen and (max-height: 700px) {
@@ -3346,10 +3005,6 @@ button.md-speed-dial-target {
   color: orange !important;
 }
 
-.code-editor {
-  height: 500px;
-}
-
 .op-button {
   font-weight: 300;
 }
@@ -3485,13 +3140,6 @@ button.md-speed-dial-target {
 
 .bold {
   font-weight: bold;
-}
-
-.carousel .carousel-nav .nav-item {
-  color: rgba(5, 142, 255, 0.5);
-}
-.carousel .carousel-nav .nav-item::before {
-  height: 0.15rem;
 }
 
 .file-dropping {

--- a/web/src/components/Preview.vue
+++ b/web/src/components/Preview.vue
@@ -1,0 +1,469 @@
+<template>
+  <div class="preview">
+    <md-dialog
+      class="plugin-dialog"
+      :md-active.sync="showAddPluginDialog"
+      :md-click-outside-to-close="show_close"
+    >
+      <md-dialog-title
+        >{{
+          plugin4install ? "Plugin Installation" : "ImJoy Plugin Management"
+        }}
+        <md-button
+          v-if="show_close"
+          class="md-accent"
+          style="position:absolute; top:8px; right:5px;"
+          @click="close()"
+          ><md-icon>clear</md-icon></md-button
+        ></md-dialog-title
+      >
+      <md-dialog-content>
+        <template v-if="show_plugin_templates">
+          <md-menu>
+            <md-button class="md-primary md-raised" md-menu-trigger>
+              <md-icon>add</md-icon>Create a new plugin
+              <md-tooltip>Create a new plugin</md-tooltip>
+            </md-button>
+            <md-menu-content>
+              <md-menu-item
+                @click="
+                  newPlugin(template.code);
+                  showAddPluginDialog = false;
+                "
+                v-for="template in plugin_templates"
+                :key="template.name"
+              >
+                <md-icon>{{ template.icon }}</md-icon
+                >{{ template.name }}
+              </md-menu-item>
+            </md-menu-content>
+          </md-menu>
+          <br />
+          <br />
+        </template>
+
+        <!-- <md-switch v-if="pm.installed_plugins.length>0 && !plugin4install && !downloading_error && !downloading_plugin" v-model="show_installed_plugins">Show Installed Plugins</md-switch> -->
+        <!-- <md-card v-if="show_installed_plugins">
+        <md-card-header>
+          <div class="md-title">Installed Plugins</div>
+        </md-card-header>
+        <md-card-content>
+          <plugin-list name="Installed Plugins" description="" v-if="pm" :plugin-manager="pm" @message="showMessage" :plugins="pm.installed_plugins" :workspace="pm.selected_workspace"></plugin-list>
+        </md-card-content>
+      </md-card> -->
+        <md-card v-if="show_plugin_url">
+          <md-card-header>
+            <div class="md-title">Install from URL</div>
+            <md-toolbar md-elevation="0">
+              <md-field md-clearable class="md-toolbar-section-start">
+                <md-icon>cloud_download</md-icon>
+                <md-input
+                  placeholder="Please paste the URL here and press enter."
+                  type="text"
+                  v-model="plugin_url"
+                  @keyup.enter="
+                    tag4install = '';
+                    getPlugin4Install(plugin_url);
+                  "
+                  name="plugin_url"
+                ></md-input>
+                <md-tooltip>Press `Enter` to get the plugin</md-tooltip>
+              </md-field>
+            </md-toolbar>
+          </md-card-header>
+        </md-card>
+        <div
+          v-if="downloading_plugin && !plugin4install"
+          class="md-toolbar-section-center"
+        >
+          <div style="padding-right: 30px;" class="loading loading-lg"></div>
+        </div>
+        <h2 v-if="downloading_error">&nbsp;&nbsp;{{ downloading_error }}</h2>
+        <md-card v-if="plugin4install">
+          <md-card-media
+            v-if="
+              plugin4install.cover && typeof plugin4install.cover === 'string'
+            "
+            md-ratio="16:9"
+          >
+            <img :src="plugin4install.cover" alt="plugin-cover" />
+          </md-card-media>
+          <div class="carousel" v-else-if="plugin4install.cover">
+            <!-- carousel locator -->
+            <input
+              v-once
+              class="carousel-locator"
+              v-for="(c, k) in plugin4install.cover"
+              :key="k"
+              :id="'slide-' + k"
+              type="radio"
+              name="carousel-radio"
+              hidden=""
+              :checked="k === 1"
+            />
+            <!-- carousel container -->
+            <div class="carousel-container">
+              <!-- carousel item -->
+              <figure
+                class="carousel-item"
+                v-for="(c, k) in plugin4install.cover"
+                :key="k"
+              >
+                <img
+                  class="img-responsive rounded"
+                  :src="c"
+                  alt="plugin cover"
+                />
+              </figure>
+            </div>
+            <!-- carousel navigation -->
+            <div class="carousel-nav">
+              <label
+                class="nav-item text-hide c-hand"
+                v-for="(c, k) in plugin4install.cover"
+                :key="k"
+                :for="'slide-' + k"
+                >{{ k }}</label
+              >
+            </div>
+          </div>
+          <md-card-header>
+            <md-toolbar md-elevation="0">
+              <div>
+                <h2>
+                  <md-icon v-if="plugin4install.icon">{{
+                    plugin4install.icon
+                  }}</md-icon
+                  ><md-icon v-else>extension</md-icon>
+                  {{ plugin4install.name + " " + plugin4install.badges }}
+                </h2>
+              </div>
+              <div v-if="installing" class="md-toolbar-section-end">
+                <div
+                  style="padding-right: 30px;"
+                  class="loading loading-lg"
+                ></div>
+              </div>
+              <div v-else-if="tag4install" class="md-toolbar-section-end">
+                <md-button
+                  class="md-button md-primary"
+                  @click="installPlugin(plugin4install, tag4install)"
+                >
+                  <md-icon>cloud_download</md-icon
+                  >{{ plugin4install._installation_text || "Install" }}
+                  <md-tooltip
+                    >Install {{ plugin4install.name }} (tag=`{{
+                      tag4install
+                    }}`)</md-tooltip
+                  >
+                </md-button>
+              </div>
+              <div v-else class="md-toolbar-section-end">
+                <md-menu
+                  v-if="plugin4install.tags && plugin4install.tags.length > 0"
+                >
+                  <md-button class="md-button md-primary" md-menu-trigger>
+                    <md-icon>cloud_download</md-icon
+                    >{{ plugin4install._installation_text || "Install" }}
+                    <md-tooltip
+                      >Choose a tag to install
+                      {{ plugin4install.name }}</md-tooltip
+                    >
+                  </md-button>
+                  <md-menu-content>
+                    <md-menu-item
+                      v-for="tag in plugin4install.tags"
+                      :key="tag"
+                      @click="installPlugin(plugin4install, tag)"
+                    >
+                      <md-icon>cloud_download</md-icon>{{ tag }}
+                    </md-menu-item>
+                  </md-menu-content>
+                </md-menu>
+                <md-button
+                  v-else
+                  class="md-button md-primary"
+                  @click="installPlugin(plugin4install)"
+                >
+                  <md-icon>cloud_download</md-icon
+                  >{{ plugin4install._installation_text || "Install" }}
+                </md-button>
+              </div>
+            </md-toolbar>
+          </md-card-header>
+          <md-card-content>
+            <p>Version: {{ plugin4install.version }}</p>
+            <p>{{ plugin4install.description }}</p>
+            <md-chip
+              v-for="tag in plugin4install.tags"
+              @click="tag4install = tag"
+              :class="tag4install === tag ? 'md-primary' : ''"
+              :key="tag"
+              >{{ tag }}</md-chip
+            >
+            <!-- <md-button class="md-button md-primary" @click="showCode(plugin4install)">
+            <md-icon>code</md-icon>Code
+          </md-button> -->
+            <br />
+            <md-switch v-if="plugin4install.code" v-model="show_plugin_source"
+              >Show plugin source code</md-switch
+            >
+            <p>
+              This plugin is <strong>NOT</strong> provided by ImJoy.io. Please
+              make sure the plugin is provided by a trusted source, otherwise it
+              may <strong>harm</strong> your computer.
+            </p>
+            <plugin-editor
+              v-if="show_plugin_source"
+              class="code-editor"
+              v-model="plugin4install.code"
+              :title="plugin4install.name"
+            ></plugin-editor>
+          </md-card-content>
+        </md-card>
+        <md-card v-show="show_plugin_store">
+          <md-card-header v-if="pm">
+            <div class="md-title">Install from the plugin repository</div>
+            <md-chips
+              @md-insert="pm.addRepository($event)"
+              @md-delete="pm.removeRepository(getRepository($event))"
+              class="md-primary shake-on-error"
+              v-model="pm.repository_names"
+              md-placeholder="Add a repository url (e.g. GITHUB REPO) and press enter."
+            >
+              <template slot="md-chip" slot-scope="{ chip }">
+                <strong
+                  class="md-primary"
+                  v-if="
+                    pm.selected_repository &&
+                      chip === pm.selected_repository.name
+                  "
+                  >{{ chip }}</strong
+                >
+                <div v-else @click="selectRepository(chip)">{{ chip }}</div>
+              </template>
+              <div class="md-helper-text" v-if="pm.selected_repository">
+                {{ pm.selected_repository.name }}:
+                {{ pm.selected_repository.description }}
+              </div>
+            </md-chips>
+          </md-card-header>
+          <md-card-content>
+            <plugin-list
+              @message="showMessage"
+              v-if="pm"
+              :plugin-manager="pm"
+              :init-search="init_plugin_search"
+              :plugins="pm.available_plugins"
+              :workspace="pm.selected_workspace"
+            ></plugin-list>
+          </md-card-content>
+        </md-card>
+      </md-dialog-content>
+    </md-dialog>
+  </div>
+</template>
+
+<script>
+import { PluginManager } from "../pluginManager.js";
+import { EngineManager } from "../engineManager.js";
+import WEB_WORKER_PLUGIN_TEMPLATE from "../plugins/webWorkerTemplate.imjoy.html";
+import NATIVE_PYTHON_PLUGIN_TEMPLATE from "../plugins/nativePythonTemplate.imjoy.html";
+import WEB_PYTHON_PLUGIN_TEMPLATE from "../plugins/webPythonTemplate.imjoy.html";
+import WINDOW_PLUGIN_TEMPLATE from "../plugins/windowTemplate.imjoy.html";
+import { randId } from "../utils.js";
+import Minibus from "minibus";
+import { ImJoy } from "../imjoyLib.js";
+
+export default {
+  name: "preview",
+  props: {
+    pluginManager: {
+      type: [PluginManager, Object],
+      default: null,
+    },
+    engineManager: {
+      type: [EngineManager, Object],
+      default: null,
+    },
+  },
+  data() {
+    return {
+      pm: null,
+      em: null,
+      plugin_templates: [],
+      showAddPluginDialog: false,
+      plugin4install: null,
+      plugin_url: null,
+      downloading_plugin: false,
+      downloading_error: "",
+      show_plugin_source: false,
+      init_plugin_search: null,
+      show_plugin_templates: true,
+      show_plugin_store: true,
+      show_plugin_url: true,
+      show_installed_plugins: false,
+      show_close: true,
+      installing: false,
+    };
+  },
+  created() {
+    this.event_bus =
+      (this.$root.$data.store && this.$root.$data.store.event_bus) ||
+      Minibus.create();
+  },
+  mounted() {
+    this.showAddPluginDialog = false;
+    this.pm = this.pluginManager;
+    this.em = this.engineManager;
+    this.plugin_templates = [
+      {
+        name: "Default template",
+        code: WEB_WORKER_PLUGIN_TEMPLATE,
+        icon: "code",
+      },
+      {
+        name: "Web Worker (JS)",
+        code: WEB_WORKER_PLUGIN_TEMPLATE,
+        icon: "swap_horiz",
+      },
+      {
+        name: "Window (HTML/CSS/JS)",
+        code: WINDOW_PLUGIN_TEMPLATE,
+        icon: "picture_in_picture",
+      },
+      {
+        name: "Native Python",
+        code: NATIVE_PYTHON_PLUGIN_TEMPLATE,
+        icon: "🚀",
+      },
+      // {name: "Iframe(Javascript)", code: IFRAME_PLUGIN_TEMPLATE},
+      { name: "Web Python", code: WEB_PYTHON_PLUGIN_TEMPLATE, icon: "🐍" },
+    ];
+    if (window.opener) {
+      if (!this.pm) {
+        const client_id = localStorage.getItem("imjoy_client_id");
+        const imjoy = new ImJoy({
+          imjoy_api: {},
+          event_bus: this.event_bus,
+          show_message_callback: msg => {
+            alert(msg);
+          },
+          update_ui_callback: () => {
+            this.$forceUpdate();
+          },
+          client_id: client_id,
+        });
+        this.pm = imjoy.pm;
+        this.em = imjoy.em;
+        imjoy.init().then(async () => {
+          await this.pm.loadWorkspace("default");
+          this.show_close = false;
+          this.downloading_error = "";
+          this.downloading_plugin = false;
+          this.showAddPluginDialog = true;
+          this.show_plugin_templates = false;
+          this.show_plugin_store = false;
+          this.show_plugin_url = false;
+          window.addEventListener("message", ev => {
+            if (ev.data.type === "load-imjoy-plugin") {
+              const code = ev.data.code;
+              let config = this.pm.parsePluginCode(code);
+              this.plugin4install = config;
+              this.tag4install = config.tag;
+              this.downloading_plugin = false;
+              this.$forceUpdate();
+            }
+          });
+          window.opener.postMessage({ type: "imjoy-app-ready" }, "*");
+        });
+      }
+    }
+    this.event_bus.on("update_preview", config => {
+      for (let k in config) {
+        this[k] = config[k];
+      }
+    });
+  },
+  methods: {
+    installPlugin(plugin4install, tag4install) {
+      this.installing = true;
+      this.pm
+        .savePlugin(plugin4install)
+        .then(template => {
+          this.close();
+          this.$router.push({
+            name: "app",
+          });
+        })
+        .finally(() => {
+          this.installing = false;
+        });
+    },
+    showMessage(msg) {
+      alert(msg);
+    },
+    newPlugin(code) {
+      const w = {
+        name: "New Plugin",
+        type: "imjoy/plugin-editor",
+        config: {},
+        plugin_manager: this.pm,
+        engine_manager: this.em,
+        w: 30,
+        h: 20,
+        standalone: this.screenWidth < 1200,
+        plugin: null,
+        data: {
+          name: "new plugin",
+          id: "plugin_" + randId(),
+          code: JSON.parse(JSON.stringify(code)),
+        },
+      };
+      this.pm.createWindow(null, w);
+    },
+    close() {
+      this.showAddPluginDialog = false;
+      const query = Object.assign({}, this.$route.query);
+      // delete query.p;
+      // delete query.plugin;
+      delete query.upgrade;
+      this.$router.replace({ query });
+      this.$forceUpdate();
+    },
+  },
+};
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+.plugin-dialog {
+  width: 80%;
+  max-width: 800px;
+  max-height: 90%;
+}
+
+@media screen and (max-width: 700px) {
+  .plugin-dialog {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+}
+
+@media screen and (max-height: 900px) {
+  .plugin-dialog {
+    max-height: 100%;
+  }
+}
+
+.carousel .carousel-nav .nav-item {
+  color: rgba(5, 142, 255, 0.5);
+}
+.carousel .carousel-nav .nav-item::before {
+  height: 0.15rem;
+}
+
+.code-editor {
+  height: 500px;
+}
+</style>

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -22,6 +22,7 @@ import FileItem from "@/components/FileItem";
 import FileDialog from "@/components/FileDialog";
 import Window from "@/components/Window";
 import EngineControlPanel from "@/components/EngineControlPanel";
+import Preview from "@/components/Preview";
 import "./registerServiceWorker";
 
 Vue.config.productionTip = false;
@@ -40,6 +41,7 @@ Vue.component("plugin-editor", PluginEditor);
 Vue.component("file-item", FileItem);
 Vue.component("file-dialog", FileDialog);
 Vue.component("window", Window);
+Vue.component("preview", Preview);
 Vue.component("grid-layout", VueGridLayout.GridLayout);
 Vue.component("grid-item", VueGridLayout.GridItem);
 Vue.component("engine-control-panel", EngineControlPanel);

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -3,7 +3,7 @@ import Router from "vue-router";
 import Imjoy from "@/components/Imjoy";
 import About from "@/components/About";
 import Home from "@/components/Home";
-
+import Preview from "@/components/Preview";
 Vue.use(Router);
 
 export const router_config = {
@@ -38,6 +38,11 @@ export const router_config = {
       path: "/about",
       name: "About",
       component: About,
+    },
+    {
+      path: "/preview",
+      name: "Preview",
+      component: Preview,
     },
     {
       path: "*",


### PR DESCRIPTION
This PR enables plugin file preview, when loading a plugin file in a browser, it will render the plugin file using imjoy.io. The user can also double click the plugin file (*.imjoy.html), it will typically open a browser.
To support it, a special script block needs to be added to the plugin file:
```
<script>
if(window && window.location && window.location.protocol === 'file:'){
    const preview = window.open("https://imjoy.io/#/preview");
    window.addEventListener("message", function(ev) {
        if (ev.data.type === "imjoy-app-ready") {
            preview.postMessage({ type: "load-imjoy-plugin", code: document.body.innerHTML }, "*");
        }
    });
}
</script>
```

When opening such a plugin file in the browser, it will be rendered as:

<img width="1303" alt="Screen Shot 2019-12-12 at 1 30 00 AM" src="https://user-images.githubusercontent.com/478667/70672280-f7f97800-1c7e-11ea-8400-34ad2caa9c6d.png">
