### PR TITLE
Support ES modules

### DIFF
--- a/web/src/jailed/_frame.js
+++ b/web/src/jailed/_frame.js
@@ -34,6 +34,7 @@ var getParamValue = function(paramName) {
 
 var plugin_name = getParamValue("name");
 var plugin_mode = getParamValue("type");
+var is_module = getParamValue("isModule");
 
 function _sendToServiceWorker(message) {
   return new Promise(function(resolve, reject) {
@@ -99,8 +100,11 @@ var initWebworkerPlugin = function() {
   ].join("\n");
 
   var blobUrl = window.URL.createObjectURL(new Blob([blobCode]));
-
-  var worker = new Worker(blobUrl, { name: plugin_name || "plugin_webworker" });
+  var worker_config = { name: plugin_name || "plugin_webworker" }
+  if(is_module){
+    worker_config.type = 'module'
+  }
+  var worker = new Worker(blobUrl, worker_config);
 
   // telling worker to load _pluginWebWorker.js (see blob code above)
   worker.postMessage({

--- a/web/src/jailed/_pluginWebIframe.js
+++ b/web/src/jailed/_pluginWebIframe.js
@@ -138,6 +138,17 @@ var execute = async function(code) {
                   code.requirements[i] = code.requirements[i].slice(3);
                 }
                 await importScripts(code.requirements[i]);
+              } else if (
+                code.requirements[i].toLowerCase().endsWith(".mjs") ||
+                code.requirements[i].startsWith("module:")
+              ) {
+                if (code.requirements[i].startsWith("module:")) {
+                  code.requirements[i] = code.requirements[i].slice(7);
+                  eval(`import "${code.requirements[i]}"`)
+                }
+                else{
+                  eval(`import "${code.requirements[i]}"`)
+                }
               } else if (code.requirements[i].startsWith("http")) {
                 await importScripts(code.requirements[i]);
               } else if (code.requirements[i].startsWith("cache:")) {

--- a/web/src/jailed/_pluginWebPython.js
+++ b/web/src/jailed/_pluginWebPython.js
@@ -181,6 +181,17 @@ var execute = async function(code) {
                 code.requirements[i] = code.requirements[i].slice(3);
               }
               await importScripts(code.requirements[i]);
+            } else if (
+              code.requirements[i].toLowerCase().endsWith(".mjs") ||
+              code.requirements[i].startsWith("module:")
+            ) {
+              if (code.requirements[i].startsWith("module:")) {
+                code.requirements[i] = code.requirements[i].slice(7);
+                eval(`import "${code.requirements[i]}"`)
+              }
+              else{
+                eval(`import "${code.requirements[i]}"`)
+              }
             } else if (code.requirements[i].startsWith("cache:")) {
               //ignore cache
             } else if (

--- a/web/src/jailed/_pluginWebWorker.js
+++ b/web/src/jailed/_pluginWebWorker.js
@@ -96,6 +96,17 @@ self.connection = {};
                     code.requirements[i] = code.requirements[i].slice(3);
                   }
                   importScripts(code.requirements[i]);
+                } else if (
+                  code.requirements[i].toLowerCase().endsWith(".mjs") ||
+                  code.requirements[i].startsWith("module:")
+                ) {
+                  if (code.requirements[i].startsWith("module:")) {
+                    code.requirements[i] = code.requirements[i].slice(7);
+                    eval(`import "${code.requirements[i]}"`)
+                  }
+                  else{
+                    eval(`import "${code.requirements[i]}"`)
+                  }
                 } else if (code.requirements[i].startsWith("http")) {
                   importScripts(code.requirements[i]);
                 } else if (code.requirements[i].startsWith("cache:")) {

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -364,6 +364,14 @@ class BasicConnection {
       config.name +
       "&workspace=" +
       config.workspace;
+    
+    if(config.attrs.type === 'module'){
+      me._frame.src = me._frame.src + "&isModule=1";
+    }
+    else{
+      me._frame.src = me._frame.src + "&isModule=0";
+    }
+    
     me._frame.id = "iframe_" + id;
     if (type == "iframe" || type == "window" || type == "web-python-window") {
       if (typeof iframe_container == "string") {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1290,14 +1290,20 @@ export class PluginManager {
       if (!config.script) {
         config.script = pluginComp.script[0].content;
         config.lang = pluginComp.script[0].attrs.lang;
+        config.attrs = pluginComp.script[0].attrs;
       }
       config.tag = overwrite_config.tag || (config.tags && config.tags[0]);
       // try to match the script with current tag
       for (let i = 0; i < pluginComp.script.length; i++) {
         if (pluginComp.script[i].attrs.tag === config.tag) {
           config.script = pluginComp.script[i].content;
+          config.lang = pluginComp.script[i].attrs.lang;
+          config.attrs = pluginComp.script[i].attrs;
           break;
         }
+      }
+      if(config.type === 'web-worker' && config.scripts.length > 1){
+        throw "web-worker plugin can only have one script block"
       }
       config.links = pluginComp.link || null;
       config.windows = pluginComp.window || null;


### PR DESCRIPTION
With ES modules, one can directly use import modules directly in the script, e.g.: `import { export1 } from "module-name";` ([more examples](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import))

This PR tries to support such syntax by allowing use `<script lang="javascript" type="module">` for Javascript plugin (`window` or `web-worker`).