### PR TITLE
Fix bug for executing multiple tagged script blocks

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.3",
+  "version": "0.10.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1283,20 +1283,25 @@ export class PluginManager {
         }
       }
 
-      config.scripts = [];
-      for (let i = 0; i < pluginComp.script.length; i++) {
-        config.scripts.push(pluginComp.script[i]);
-      }
       if (!config.script) {
         config.script = pluginComp.script[0].content;
         config.lang = pluginComp.script[0].attrs.lang;
       }
       config.tag = overwrite_config.tag || (config.tags && config.tags[0]);
+
+      config.scripts = [];
       // try to match the script with current tag
       for (let i = 0; i < pluginComp.script.length; i++) {
         if (pluginComp.script[i].attrs.tag === config.tag) {
           config.script = pluginComp.script[i].content;
-          break;
+        }
+
+        // exclude script with mismatched tag
+        if (
+          !pluginComp.script[i].attrs.tag ||
+          pluginComp.script[i].attrs.tag === config.tag
+        ) {
+          config.scripts.push(pluginComp.script[i]);
         }
       }
       config.links = pluginComp.link || null;

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1955,7 +1955,11 @@ export class PluginManager {
           this.registered.loaders[op_key] = async target => {
             let config = {};
             if (plugin.config && plugin.config.ui) {
-              config = await this.imjoy_api.showDialog(plugin, plugin.config);
+              config = await this.imjoy_api.showDialog(plugin, {
+                type: "imjoy/joy",
+                ui: plugin.config.ui,
+                name: plugin.config.name,
+              });
             }
             target.transfer = target.transfer || false;
             target._source_op = target._op;


### PR DESCRIPTION
When multiple script blocks are tagged, the current implementation will execute all of the script block. This PR exclude those tagged script blocks, and only include non-tagged scripts or matched scripts. 

[Test case for this issue](https://gist.githubusercontent.com/oeway/25353f6cd5198850922e2c6aebe58fe9/raw/9aa01d1e6691bad2185af8618bc3bd627773e6c0/M2Unet-Demo.imjoy.html)