### PR TITLE
Support gist url (not raw)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1217,8 +1217,10 @@ There are **two types of URI**, depending on how your plugin is deployed:
     1. For files on **GitHub**, you just need to copy the link to the file.
        For example: `https://github.com/oeway/ImJoy-Plugins/blob/master/repository/imageRecognition.imjoy.html`.
 
-    0.  For **Gist** or other Git providers such as (GitLab), you need to obtain the `raw`
-        link of the plugin file. For example, to create a Gist link
+    0.  For **Gist** or other Git providers such as (GitLab), if there is only one file in the Gist, you can use the direct Gist link (copied from your browser address bar) or obtain the `raw`
+        link of the plugin file. For a Gist with multiple file, you need to specify the `raw` link for the plugin file you would like to use. 
+        
+        To create a Gist `raw` link:
 
         1. Go to Gist on your GitHub account [https://gist.github.com/](https://gist.github.com/)
         0. Create new Gist, specify the plugin name followed by `.imjoy.html`, and copy & paste the code of your plugin.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -802,8 +802,11 @@ export class PluginManager {
   async getPluginFromUrl(uri, scoped_plugins) {
     scoped_plugins = scoped_plugins || this.available_plugins;
     let selected_tag;
-    if (uri.includes("github") && uri.includes("/blob/")) {
-      uri = githubUrlRaw(uri);
+    if (
+      (uri.includes("github.com") && uri.includes("/blob/")) ||
+      uri.includes("gist.github.com")
+    ) {
+      uri = await githubUrlRaw(uri);
     }
     // if the uri format is REPO_NAME:PLUGIN_NAME
     if (!uri.startsWith("http") && uri.includes("/") && uri.includes(":")) {

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1955,7 +1955,11 @@ export class PluginManager {
           this.registered.loaders[op_key] = async target => {
             let config = {};
             if (plugin.config && plugin.config.ui) {
-              config = await this.imjoy_api.showDialog(plugin, plugin.config);
+              config = await this.imjoy_api.showDialog(plugin, {
+                type: "imjoy/joy",
+                ui: plugin.config.ui,
+                name: plugin.config.name,
+              });
             }
             target.transfer = target.transfer || false;
             target._source_op = target._op;

--- a/web/src/utils.js
+++ b/web/src/utils.js
@@ -1,4 +1,5 @@
 /*eslint no-useless-escape: "off"*/
+import axios from "axios";
 
 /**
  * A special kind of event:
@@ -1043,7 +1044,20 @@ export function githubUrlToObject(repoUrl, opts) {
 }
 
 // from: https://github.com/Elixirdoc/github-url-raw
-export function githubUrlRaw(url) {
+export async function githubUrlRaw(url) {
+  if (url.includes("gist.github.com")) {
+    const gistId = url.split("/").slice(-1)[0];
+    const response = await axios.get("https://api.github.com/gists/" + gistId);
+    if (response.status === 200) {
+      // TODO: handle multiple files, e.g.: display them all
+      const plugin_file = Object.values(response.data.files).filter(file => {
+        return file.filename.endsWith(".imjoy.html");
+      })[0];
+      return plugin_file.raw_url;
+    } else {
+      throw "Failed to fetch from Gist: " + response.statusText;
+    }
+  }
   if (!url.includes("blob") || !url.includes("github")) {
     return null;
   }


### PR DESCRIPTION
Previously, plugin files on Gist can only be installed if the user retrieve raw url directly.

This PR uses gist api (https://developer.github.com/v3/gists/) to retrieve raw url stored on gist, such that user will be able to pass the direct gist url to ImJoy. 

A direct gist url (e.g.: https://gist.github.com/oeway/25353f6cd5198850922e2c6aebe58fe9) can be appended after `https://imjoy.io/#/app?plugin=` or `https://imjoy.io/lite?plugin=`, or pasted into the plugin management dialog.