### PR TITLE
Allow empty script tag

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/jailed/jailed.js
+++ b/web/src/jailed/jailed.js
@@ -476,9 +476,6 @@ class BasicConnection {
  */
 var DynamicPlugin = function(config, _interface, _fs_api, engine, is_proxy) {
   this.config = config;
-  if (!this.config.script) {
-    throw "you must specify the script for the plugin to run.";
-  }
   this.id = config.id || randId();
   this._id = config._id;
   this.name = config.name;

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1955,7 +1955,11 @@ export class PluginManager {
           this.registered.loaders[op_key] = async target => {
             let config = {};
             if (plugin.config && plugin.config.ui) {
-              config = await this.imjoy_api.showDialog(plugin, plugin.config);
+              config = await this.imjoy_api.showDialog(plugin, {
+                type: "imjoy/joy",
+                ui: plugin.config.ui,
+                name: plugin.config.name,
+              });
             }
             target.transfer = target.transfer || false;
             target._source_op = target._op;


### PR DESCRIPTION
For the [Juptyer Engine plugin](https://github.com/imjoy-team/jupyter-engine-manager/blob/master/src/Jupyter-Engine-Manager.imjoy.html), the script tag is empty which is not allowed currently.

This is a fix to allow an empty script tag.