### PR TITLE
Allow no script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2687,7 +2687,7 @@ export default {
         .execute(mw.target)
         .then(my => {
           const w = this.pm.joy2plugin(my);
-          if (w && !my.__jailed_type__) {
+          if (w && !my.__as_interface__) {
             w.name = w.name || "result";
             w.type = w.type || "imjoy/generic";
             this.createWindow(w);
@@ -2797,7 +2797,7 @@ export default {
         this.showMessage("Uploading a file to " + config.url);
         let totalLength = null;
         axios({
-          method: "post" || config.method,
+          method: "post",
           url: config.url,
           data: bodyFormData,
           headers: config.headers || { "Content-Type": "multipart/form-data" },

--- a/web/src/components/PluginEditor.vue
+++ b/web/src/components/PluginEditor.vue
@@ -394,7 +394,7 @@ export default {
         (plugin.config && plugin.config.type === "window") ||
         plugin.config.type === "web-python-window"
       ) {
-        this.window_plugin_id = w.__id__;
+        this.window_plugin_id = w && w.__id__;
         this.window_plugin_config = config;
       }
     },

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1286,10 +1286,6 @@ export class PluginManager {
         }
       }
 
-      if (!config.script) {
-        config.script = pluginComp.script[0].content;
-        config.lang = pluginComp.script[0].attrs.lang;
-      }
       config.tag = overwrite_config.tag || (config.tags && config.tags[0]);
 
       config.scripts = [];
@@ -1306,6 +1302,10 @@ export class PluginManager {
         ) {
           config.scripts.push(pluginComp.script[i]);
         }
+      }
+      if (!config.script && pluginComp.script.length>0) {
+        config.script = pluginComp.script[0].content;
+        config.lang = pluginComp.script[0].attrs.lang;
       }
       config.links = pluginComp.link || null;
       config.windows = pluginComp.window || null;

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1427,7 +1427,7 @@ export class PluginManager {
           c.data = (my && my.data) || {};
           c.config = (my && my.config) || {};
           c.id = my && my.id;
-          await this.createWindow(null, c);
+          return await this.createWindow(null, c);
         },
       };
       try {
@@ -1696,7 +1696,8 @@ export class PluginManager {
     if (!my) return null;
     //conver config--> data  data-->target
     const res = {};
-    res.__jailed_type__ = my.__jailed_type__;
+    res.__as_interface__ = my.__as_interface__;
+    res.__id__ = my.__id__;
     if (my.type && my.data) {
       res.data = my.config;
       res.target = my.data;
@@ -1748,7 +1749,8 @@ export class PluginManager {
     if (!my) return null;
     my.target = my.target || {};
     const ret = {
-      __jailed_type__: my.__jailed_type__,
+      __as_interface__: my.__as_interface__,
+      __id__: my.__id__,
       _variables: my.target._variables || null,
       _op: my.target._op,
       _source_op: my.target._source_op,
@@ -1979,7 +1981,8 @@ export class PluginManager {
             const result = await plugin.api.run(this.joy2plugin(my));
             if (result) {
               const res = this.plugin2joy(result);
-              if (res) {
+              // if it's not a window
+              if (res && !res.__as_interface__) {
                 const w = {};
                 w.name = res.name || "result";
                 w.type = res.type || "imjoy/generic";

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1955,7 +1955,11 @@ export class PluginManager {
           this.registered.loaders[op_key] = async target => {
             let config = {};
             if (plugin.config && plugin.config.ui) {
-              config = await this.imjoy_api.showDialog(plugin, plugin.config);
+              config = await this.imjoy_api.showDialog(plugin, {
+                type: "imjoy/joy",
+                ui: plugin.config.ui,
+                name: plugin.config.name,
+              });
             }
             target.transfer = target.transfer || false;
             target._source_op = target._op;

--- a/web/src/pluginManager.js
+++ b/web/src/pluginManager.js
@@ -1303,7 +1303,7 @@ export class PluginManager {
           config.scripts.push(pluginComp.script[i]);
         }
       }
-      if (!config.script && pluginComp.script.length>0) {
+      if (!config.script && pluginComp.script.length > 0) {
         config.script = pluginComp.script[0].content;
         config.lang = pluginComp.script[0].attrs.lang;
       }


### PR DESCRIPTION
This PR allows no script tag at all. Note, you will still need a script, but you can provide it via `requirements`.

* this also fixes a bug for the code editor, when running a `window` plugin via the play button, the window doesn't get reloaded.