### PR TITLE
Add maxLength to speed up type validation

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -417,6 +417,8 @@ Defines the inputs with json-schema syntax (http://json-schema.org/).
 
 For example, to define that the plugin uses png files, you can specify `"inputs": {"properties": {"type": {"enum": ["image/png"]}}, "type": "object"}` . You can also use the simplified format which assumes the inputs is an object and use json schema to describe the properties: `"inputs": {"type": {"enum": ["image/png"]}}`.
 
+Please also note that if you use a regular expression pattern in the schema to validate an string, you may want to set the `maxLength`, otherwise it will be very slow and can even crash while validating large string. For example, if we want to match an object contains `file_name` which ends with `.tiff`, we can set: `{"properties": {"file_name": {"type": "string","pattern": ".*\\.tiff$", "maxLength": 1024}}}`.
+
 #### outputs
 Defines the outputs with json-schema syntax (http://json-schema.org/).
 The format is the same as for `inputs`.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ImJoy.io",
-  "version": "0.10.18",
+  "version": "0.10.19",
   "private": true,
   "description": "ImJoy -- deep learning made easy.",
   "author": "Wei OUYANG <wei.ouyang@cri-paris.org>",

--- a/web/src/components/EngineControlPanel.vue
+++ b/web/src/components/EngineControlPanel.vue
@@ -45,6 +45,10 @@
               <md-icon v-else-if="engine.connected" class="md-primary"
                 >autorenew</md-icon
               >
+              <div
+                v-else-if="engine.connecting"
+                class="loading loading-lg"
+              ></div>
               <md-icon v-else>sync_disabled</md-icon>
               <span>{{ engine.name.slice(0, 20) }}</span>
               <md-button
@@ -534,8 +538,16 @@ export default {
       }
     },
     async connectEngine(engine) {
-      if (!engine.connected) await engine.connect();
-      this.$forceUpdate();
+      try {
+        if (!engine.connected) {
+          engine.connecting = true;
+          await engine.connect();
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        engine.connecting = false;
+      }
     },
     async disconnectEngine(engine) {
       if (engine.connected) {

--- a/web/src/components/FileDialog.vue
+++ b/web/src/components/FileDialog.vue
@@ -382,6 +382,7 @@ export default {
                 .then(url => {
                   if (this.options.return_object) {
                     resolve2({
+                      type: "imjoy/url",
                       url: url,
                       file_manager: this.selected_file_manager.url,
                       path: paths,
@@ -405,6 +406,7 @@ export default {
                 .then(urls => {
                   if (this.options.return_object) {
                     resolve2({
+                      type: "imjoy/url",
                       url: urls,
                       file_manager: this.selected_file_manager.url,
                       path: paths,

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2138,10 +2138,15 @@ export default {
           loader_key: "Code Editor (file)",
           schema: ajv.compile({
             properties: {
-              name: { type: "string", pattern: ".*\\.imjoy.html$" },
+              type: { type: "string" },
+              name: {
+                type: "string",
+                pattern: ".*\\.imjoy.html$",
+                maxLength: 1024,
+              },
               size: { type: "number" },
             },
-            required: ["name", "size"],
+            required: ["name", "size", "type"],
           }),
           loader: code_loader,
         },
@@ -2149,7 +2154,12 @@ export default {
           loader_key: "Code Editor (url)",
           schema: ajv.compile({
             properties: {
-              url: { type: "string", pattern: ".*\\.imjoy.html$" },
+              type: { type: "string", enum: ["imjoy/url"] },
+              url: {
+                type: "string",
+                pattern: ".*\\.imjoy.html$",
+                maxLength: 1024,
+              },
               path: { type: "string" },
               engine: { type: "string" },
             },
@@ -2175,14 +2185,16 @@ export default {
           loader_key: "Image (url)",
           schema: ajv.compile({
             properties: {
+              type: { type: "string", enum: ["imjoy/url"] },
               url: {
                 type: "string",
+                maxLength: 1024,
                 pattern: "(.*\\.jpg|\\.jpeg|\\.png|\\.gif)$",
               },
               path: { type: "string" },
               engine: { type: "string" },
             },
-            required: ["url", "path", "engine"],
+            required: ["url", "path", "engine", "type"],
           }),
           loader: engine_image_loader,
         },
@@ -2687,7 +2699,8 @@ export default {
       this.status_text = "";
       this.progress = 0;
       let mw;
-      if (op.inputs_schema) {
+      // for performance concerns, we need to have `type` in the data
+      if (op.inputs_schema && typeof w.data.type === "string") {
         const w =
           this.wm.active_windows[this.wm.active_windows.length - 1] || {};
         if (op.inputs_schema(w.data)) {

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2075,7 +2075,7 @@ export default {
           this.createWindow({
             name: file.name,
             type: "imjoy/image",
-            data: { src: reader.result, _file: file },
+            data: { type: "imjoy/image", src: reader.result, file: file },
           });
         };
         reader.readAsDataURL(file);
@@ -2093,6 +2093,7 @@ export default {
           standalone: this.screenWidth < 1200,
           plugin: {},
           data: {
+            type: "imjoy/code",
             name: "new plugin",
             id: "plugin_" + randId(),
             code: "",
@@ -2114,6 +2115,7 @@ export default {
           standalone: this.screenWidth < 1200,
           plugin: {},
           data: {
+            type: "imjoy/code",
             name: "new plugin",
             id: "plugin_" + randId(),
             code: "",
@@ -2129,7 +2131,7 @@ export default {
         this.createWindow({
           name: file_name,
           type: "imjoy/image",
-          data: { src: engine_image_file.url },
+          data: { type: "imjoy/image", src: engine_image_file.url },
         });
       };
 
@@ -2700,10 +2702,10 @@ export default {
       this.progress = 0;
       let mw;
       // for performance concerns, we need to have `type` in the data
-      if (op.inputs_schema && typeof w.data.type === "string") {
+      if (op.inputs_schema) {
         const w =
           this.wm.active_windows[this.wm.active_windows.length - 1] || {};
-        if (op.inputs_schema(w.data)) {
+        if (w.data && op.inputs_schema(w.data)) {
           mw = this.pm.plugin2joy(w) || {};
         } else {
           mw = {};

--- a/web/src/components/Imjoy.vue
+++ b/web/src/components/Imjoy.vue
@@ -2592,6 +2592,7 @@ export default {
         standalone: this.screenWidth < 1200,
         plugin: null,
         data: {
+          type: "imjoy/code",
           name: "new plugin",
           id: "plugin_" + randId(),
           code: JSON.parse(JSON.stringify(code)),

--- a/web/src/windowManager.js
+++ b/web/src/windowManager.js
@@ -66,13 +66,17 @@ export class WindowManager {
   }
 
   getDataLoaders(data) {
+    if (!data.type) {
+      console.warn(
+        "Skipping getDataLoaders, no type property contained in data: ",
+        data
+      );
+      return {};
+    }
     const loaders = {};
     // find all the plugins registered for this type
     for (let k in this.registered_inputs) {
       if (this.registered_inputs.hasOwnProperty(k)) {
-        // const error = this.registered_inputs[k].schema.errors
-        // console.error("schema mismatch: ", data, error)
-
         if (
           this.registered_inputs[k].loader_key &&
           this.registered_inputs[k].schema(data)

--- a/web/src/windowManager.js
+++ b/web/src/windowManager.js
@@ -74,8 +74,8 @@ export class WindowManager {
         // console.error("schema mismatch: ", data, error)
 
         if (
-          this.registered_inputs[k].schema(data) &&
-          this.registered_inputs[k].loader_key
+          this.registered_inputs[k].loader_key &&
+          this.registered_inputs[k].schema(data)
         ) {
           try {
             const loader_key = this.registered_inputs[k].loader_key;

--- a/web/src/windowManager.js
+++ b/web/src/windowManager.js
@@ -66,13 +66,6 @@ export class WindowManager {
   }
 
   getDataLoaders(data) {
-    if (!data.type) {
-      console.warn(
-        "Skipping getDataLoaders, no type property contained in data: ",
-        data
-      );
-      return {};
-    }
     const loaders = {};
     // find all the plugins registered for this type
     for (let k in this.registered_inputs) {


### PR DESCRIPTION

When displaying an image encoded with base64,  ImJoy becomes extremely slow, or even crash.

(The issue is reported by @muellerflorian )

This is because we use json schema to validate the data type, we use [ajv](https://github.com/epoberezkin/ajv) to perform object type validation, when a big string is passed to the validator, it becomes very slow.

One way to mitigate is to add a maxLength property to the schema we used. 
However, this is a temporary solution, there maybe  other schema from plugins, we need a more performant way of data type checking.